### PR TITLE
Ps rest connection post

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/CIEnvironmentVariables.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/CIEnvironmentVariables.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub;
 
 import java.util.HashMap;

--- a/src/main/java/com/blackducksoftware/integration/hub/HubSupportHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/HubSupportHelper.java
@@ -24,11 +24,14 @@ package com.blackducksoftware.integration.hub;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URISyntaxException;
+import java.util.EnumSet;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.restlet.resource.ResourceException;
 
 import com.blackducksoftware.integration.hub.api.VersionComparison;
+import com.blackducksoftware.integration.hub.capabilities.HubCapabilitiesEnum;
 import com.blackducksoftware.integration.hub.exception.BDRestException;
 import com.blackducksoftware.integration.hub.logging.IntLogger;
 
@@ -40,46 +43,41 @@ public class HubSupportHelper implements Serializable {
 	public static final String MAC_CLI_DOWNLOAD = "scan.cli-macosx.zip";
 
 	private boolean hasBeenChecked = false;
-	private boolean hub3_0Support = false;
-	private boolean hub3_1Support = false;
-	private boolean hub3_4Support = false;
+
+	private final Set<HubCapabilitiesEnum> capabilities = EnumSet.noneOf(HubCapabilitiesEnum.class);
 
 	/**
 	 * CLI wrappers were packaged with OS specific Jre's since Hub 3.0.0
 	 */
+	@Deprecated
 	public boolean isJreProvidedSupport() {
-		return hub3_0Support;
+		return hasCapability(HubCapabilitiesEnum.JRE_PROVIDED);
 	}
 
 	/**
 	 * Policy Api's were added since Hub 3.0.0
 	 */
+	@Deprecated
 	public boolean isPolicyApiSupport() {
-		return hub3_0Support;
+		return hasCapability(HubCapabilitiesEnum.POLICY_API);
 	}
 
 	/**
 	 * The CLI started supporting an option to print status files to a directory
 	 * since Hub 3.0.0
 	 */
+	@Deprecated
 	public boolean isCliStatusDirOptionSupport() {
-		return hub3_0Support;
+		return hasCapability(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION);
 	}
 
 	/**
 	 * The CLI requires the password be provided as an environment variable
 	 * since Hub 3.1.0
 	 */
+	@Deprecated
 	public boolean isCliPasswordEnvironmentVar() {
-		return hub3_1Support;
-	}
-
-	private void setHub3_0Support(final boolean hub3_0Support) {
-		this.hub3_0Support = hub3_0Support;
-	}
-
-	private void setHub3_1Support(final boolean hub3_1Support) {
-		this.hub3_1Support = hub3_1Support;
+		return hasCapability(HubCapabilitiesEnum.CLI_PASSWORD_ENVIRONMENT_VARIABLE);
 	}
 
 	public boolean isHasBeenChecked() {
@@ -101,18 +99,15 @@ public class HubSupportHelper implements Serializable {
 			final String hubServerVersion = service.getHubVersion();
 
 			if (compareVersion(hubServerVersion, "3.4.0", service)) {
-				setHub3_4Support(true);
-				setHub3_1Support(true);
-				setHub3_0Support(true);
+				setHub3_4Support();
+				setHub3_1Support();
+				setHub3_0Support();
 			} else if (compareVersion(hubServerVersion, "3.1.0", service)) {
-				setHub3_1Support(true);
-				setHub3_0Support(true);
+				setHub3_1Support();
+				setHub3_0Support();
 			} else {
-				setHub3_1Support(false);
 				if (compareVersion(hubServerVersion, "3.0.0", service)) {
-					setHub3_0Support(true);
-				} else {
-					setHub3_0Support(false);
+					setHub3_0Support();
 				}
 			}
 			setHasBeenChecked(true);
@@ -264,15 +259,21 @@ public class HubSupportHelper implements Serializable {
 		return urlBuilder.toString();
 	}
 
-	public boolean isHub3_4Support() {
-		return hub3_4Support;
+	public boolean hasCapability(final HubCapabilitiesEnum capability) {
+		return capabilities.contains(capability);
 	}
 
-	private void setHub3_4Support(final boolean hub3_4Support) {
-		this.hub3_4Support = hub3_4Support;
+	private void setHub3_0Support() {
+		capabilities.add(HubCapabilitiesEnum.JRE_PROVIDED);
+		capabilities.add(HubCapabilitiesEnum.POLICY_API);
+		capabilities.add(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION);
 	}
 
-	public boolean isBomFileUploadSupported() {
-		return hub3_4Support;
+	private void setHub3_1Support() {
+		capabilities.add(HubCapabilitiesEnum.CLI_PASSWORD_ENVIRONMENT_VARIABLE);
+	}
+
+	private void setHub3_4Support() {
+		capabilities.add(HubCapabilitiesEnum.BOM_FILE_UPLOAD);
 	}
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/HubSupportHelper.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/HubSupportHelper.java
@@ -42,6 +42,7 @@ public class HubSupportHelper implements Serializable {
 	private boolean hasBeenChecked = false;
 	private boolean hub3_0Support = false;
 	private boolean hub3_1Support = false;
+	private boolean hub3_4Support = false;
 
 	/**
 	 * CLI wrappers were packaged with OS specific Jre's since Hub 3.0.0
@@ -99,7 +100,11 @@ public class HubSupportHelper implements Serializable {
 		try {
 			final String hubServerVersion = service.getHubVersion();
 
-			if (compareVersion(hubServerVersion, "3.1.0", service)) {
+			if (compareVersion(hubServerVersion, "3.4.0", service)) {
+				setHub3_4Support(true);
+				setHub3_1Support(true);
+				setHub3_0Support(true);
+			} else if (compareVersion(hubServerVersion, "3.1.0", service)) {
 				setHub3_1Support(true);
 				setHub3_0Support(true);
 			} else {
@@ -259,4 +264,15 @@ public class HubSupportHelper implements Serializable {
 		return urlBuilder.toString();
 	}
 
+	public boolean isHub3_4Support() {
+		return hub3_4Support;
+	}
+
+	private void setHub3_4Support(final boolean hub3_4Support) {
+		this.hub3_4Support = hub3_4Support;
+	}
+
+	public boolean isBomFileUploadSupported() {
+		return hub3_4Support;
+	}
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/capabilities/HubCapabilitiesEnum.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/capabilities/HubCapabilitiesEnum.java
@@ -19,30 +19,9 @@
  * specific language governing permissions and limitations
  * under the License.
  *******************************************************************************/
-package com.blackducksoftware.integration.hub.exception;
+package com.blackducksoftware.integration.hub.capabilities;
 
-public class UnexpectedHubResponseException extends Exception {
-
-	private static final long serialVersionUID = -6736510347450951980L;
-
-	public UnexpectedHubResponseException() {
-	}
-
-	public UnexpectedHubResponseException(final String message) {
-		super(message);
-	}
-
-	public UnexpectedHubResponseException(final Throwable cause) {
-		super(cause);
-	}
-
-	public UnexpectedHubResponseException(final String message, final Throwable cause) {
-		super(message, cause);
-	}
-
-	public UnexpectedHubResponseException(final String message, final Throwable cause, final boolean enableSuppression,
-			final boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
+public enum HubCapabilitiesEnum {
+	JRE_PROVIDED, POLICY_API, CLI_STATUS_DIRECTORY_OPTION, CLI_PASSWORD_ENVIRONMENT_VARIABLE, BOM_FILE_UPLOAD;
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/cli/CLILocation.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/cli/CLILocation.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.cli;
 
 import java.io.File;

--- a/src/main/java/com/blackducksoftware/integration/hub/item/HubItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/item/HubItem.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.item;
 
 import java.util.ArrayList;

--- a/src/main/java/com/blackducksoftware/integration/hub/item/HubItems.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/item/HubItems.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.item;
 
 import java.util.List;

--- a/src/main/java/com/blackducksoftware/integration/hub/item/HubItemsService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/item/HubItemsService.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.item;
 
 import java.io.IOException;

--- a/src/main/java/com/blackducksoftware/integration/hub/policy/api/PolicyRule.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/policy/api/PolicyRule.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.policy.api;
 
 import org.joda.time.DateTime;

--- a/src/main/java/com/blackducksoftware/integration/hub/policy/api/PolicyRuleConditionFieldEnum.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/policy/api/PolicyRuleConditionFieldEnum.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.policy.api;
 
 public enum PolicyRuleConditionFieldEnum {

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.rest;
 
 import java.io.BufferedReader;

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -445,30 +445,7 @@ public class RestConnection {
 		final ClientResource resource = createClientResource(url);
 		resource.setMethod(Method.POST);
 		resource.getRequest().setEntity(content);
-		handleRequest(resource);
-
-		logMessage(LogLevel.DEBUG, "Resource: " + resource);
-		final int responseCode = getResponseStatusCode(resource);
-		if (isPostSuccess(responseCode)) {
-			if (resource.getResponse().getAttributes() == null
-					|| resource.getResponse().getAttributes().get(HeaderConstants.ATTRIBUTE_HEADERS) == null) {
-				throw new ResourceDoesNotExistException(
-						"Could not get the response headers after creating the resource.", resource);
-			}
-			@SuppressWarnings("unchecked")
-			final Series<Header> responseHeaders = (Series<Header>) resource.getResponse().getAttributes()
-					.get(HeaderConstants.ATTRIBUTE_HEADERS);
-			final Header resourceUrl = responseHeaders.getFirst("location", true);
-
-			if (resourceUrl == null || StringUtils.isBlank(resourceUrl.getValue())) {
-				throw new ResourceDoesNotExistException("Could not get the project URL from the response headers.",
-						resource);
-			}
-			return resourceUrl.getValue();
-		} else {
-			throw new ResourceDoesNotExistException(
-					"There was a problem creating the resource. Error Code: " + responseCode, resource);
-		}
+		return handleHttpPost(resource);
 	}
 
 	public String httpPostFromRelativeUrl(final List<String> urlSegments,
@@ -478,6 +455,12 @@ public class RestConnection {
 		final ClientResource resource = createClientResource(urlSegments, queryParameters);
 		resource.setMethod(Method.POST);
 		resource.getRequest().setEntity(content);
+		return handleHttpPost(resource);
+	}
+
+	private String handleHttpPost(final ClientResource resource)
+			throws IOException, ResourceDoesNotExistException, URISyntaxException, BDRestException {
+
 		handleRequest(resource);
 
 		logMessage(LogLevel.DEBUG, "Resource: " + resource);
@@ -495,7 +478,7 @@ public class RestConnection {
 			final Header resourceUrl = responseHeaders.getFirst("location", true);
 
 			if (resourceUrl == null || StringUtils.isBlank(resourceUrl.getValue())) {
-				throw new ResourceDoesNotExistException("Could not get the project URL from the response headers.",
+				throw new ResourceDoesNotExistException("Could not get the resource URL from the response headers.",
 						resource);
 			}
 			return resourceUrl.getValue();

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -28,6 +28,8 @@ import java.net.CookieHandler;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -467,6 +469,12 @@ public class RestConnection {
 		resource.setMethod(Method.POST);
 		resource.getRequest().setEntity(content);
 		return handleHttpPost(resource);
+	}
+
+	public String httpPostFromRelativeUrl(final List<String> urlSegments, final Representation content)
+			throws IOException, ResourceDoesNotExistException, URISyntaxException, BDRestException {
+		final Set<SimpleEntry<String, String>> queryParameters = new HashSet<SimpleEntry<String, String>>();
+		return httpPostFromRelativeUrl(urlSegments, queryParameters, content);
 	}
 
 	public String httpPostFromRelativeUrl(final List<String> urlSegments,

--- a/src/test/java/com/blackducksoftware/integration/hub/HubSupportHelperTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/HubSupportHelperTest.java
@@ -22,6 +22,7 @@
 package com.blackducksoftware.integration.hub;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -30,227 +31,273 @@ import org.restlet.data.Status;
 import org.restlet.resource.ResourceException;
 
 import com.blackducksoftware.integration.hub.api.VersionComparison;
+import com.blackducksoftware.integration.hub.capabilities.HubCapabilitiesEnum;
 import com.blackducksoftware.integration.hub.exception.BDRestException;
 import com.blackducksoftware.integration.hub.util.TestLogger;
 
 public class HubSupportHelperTest {
 
-    private HubIntRestService getMockedService(String returnVersion) throws Exception {
-        HubIntRestService service = Mockito.mock(HubIntRestService.class);
-        Mockito.when(service.getHubVersion()).thenReturn(returnVersion);
-        return service;
-    }
+	private HubIntRestService getMockedService(final String returnVersion) throws Exception {
+		final HubIntRestService service = Mockito.mock(HubIntRestService.class);
+		Mockito.when(service.getHubVersion()).thenReturn(returnVersion);
+		return service;
+	}
 
-    private HubIntRestService getMockedServiceWithFallBack(String returnVersion, boolean compareSupported) throws Exception {
-        HubIntRestService service = getMockedService(returnVersion);
-        VersionComparison compare;
-        if (compareSupported) {
-            compare = new VersionComparison("", "", -1, "");
-        } else {
-            compare = new VersionComparison("", "", 1, "");
-        }
-        Mockito.when(service.compareWithHubVersion(Mockito.anyString())).thenReturn(compare);
-        return service;
-    }
+	private HubIntRestService getMockedServiceWithFallBack(final String returnVersion, final boolean compareSupported)
+			throws Exception {
+		final HubIntRestService service = getMockedService(returnVersion);
+		VersionComparison compare;
+		if (compareSupported) {
+			compare = new VersionComparison("", "", -1, "");
+		} else {
+			compare = new VersionComparison("", "", 1, "");
+		}
+		Mockito.when(service.compareWithHubVersion(Mockito.anyString())).thenReturn(compare);
+		return service;
+	}
 
-    @Test
-    public void testJreProvided() throws Exception {
-        HubIntRestService service = getMockedService("3.0.0");
-        HubSupportHelper supportHelper = new HubSupportHelper();
-        TestLogger logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+	@Test
+	public void testJreProvided() throws Exception {
+		HubIntRestService service = getMockedService("3.0.0");
+		HubSupportHelper supportHelper = new HubSupportHelper();
+		TestLogger logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
 
-        service = getMockedService("3.0.1");
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("3.0.1");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
-        assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION));
 
-        service = getMockedService("3.1.0");
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("3.1.0");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
-        assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isCliPasswordEnvironmentVar());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_PASSWORD_ENVIRONMENT_VARIABLE));
 
-        service = getMockedService("4.0.0");
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("3.4.0");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
-        assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isCliPasswordEnvironmentVar());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_PASSWORD_ENVIRONMENT_VARIABLE));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.BOM_FILE_UPLOAD));
 
-        service = getMockedService("3.0.0-SNAPSHOT");
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("4.0.0");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(!supportHelper.isJreProvidedSupport());
-        assertTrue(!supportHelper.isPolicyApiSupport());
-        assertTrue(!supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isCliStatusDirOptionSupport());
+		assertTrue(supportHelper.isCliPasswordEnvironmentVar());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_STATUS_DIRECTORY_OPTION));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.CLI_PASSWORD_ENVIRONMENT_VARIABLE));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.BOM_FILE_UPLOAD));
 
-        service = getMockedService("2.9.9");
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("3.0.0-SNAPSHOT");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isHasBeenChecked());
-        assertTrue(!supportHelper.isJreProvidedSupport());
-        assertTrue(!supportHelper.isPolicyApiSupport());
-        assertTrue(!supportHelper.isCliStatusDirOptionSupport());
-    }
+		assertTrue(supportHelper.isHasBeenChecked());
+		for (final HubCapabilitiesEnum value : HubCapabilitiesEnum.values()) {
+			assertFalse(supportHelper.hasCapability(value));
+		}
 
-    @Test
-    public void testCheckHubSupportFallback() throws Exception {
-        HubIntRestService service = getMockedServiceWithFallBack("Two.one.zero", true);
-        HubSupportHelper supportHelper = new HubSupportHelper();
-        TestLogger logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+		service = getMockedService("2.9.9");
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isHasBeenChecked());
+		for (final HubCapabilitiesEnum value : HubCapabilitiesEnum.values()) {
+			assertFalse(supportHelper.hasCapability(value));
+		}
+	}
 
-        service = getMockedServiceWithFallBack("3.0", true);
-        supportHelper = new HubSupportHelper();
-        logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+	@Test
+	public void testCheckHubSupportFallback() throws Exception {
+		HubIntRestService service = getMockedServiceWithFallBack("Two.one.zero", true);
+		HubSupportHelper supportHelper = new HubSupportHelper();
+		TestLogger logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(supportHelper.isJreProvidedSupport());
-        assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
 
-    }
+		service = getMockedServiceWithFallBack("3.0", true);
+		supportHelper = new HubSupportHelper();
+		logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-    @Test
-    public void testHubVersionApiMissing() throws Exception {
-        HubIntRestService service = getMockedService("2.0.1");
-        ResourceException cause = new ResourceException(Status.CLIENT_ERROR_NOT_FOUND);
-        BDRestException exception = new BDRestException("", cause, null);
-        Mockito.when(service.getHubVersion()).thenThrow(exception);
+		assertTrue(supportHelper.isJreProvidedSupport());
+		assertTrue(supportHelper.isPolicyApiSupport());
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.JRE_PROVIDED));
+		assertTrue(supportHelper.hasCapability(HubCapabilitiesEnum.POLICY_API));
 
-        HubSupportHelper supportHelper = new HubSupportHelper();
-        TestLogger logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+	}
 
-        assertTrue(!supportHelper.isJreProvidedSupport());
-        assertTrue(!supportHelper.isPolicyApiSupport());
+	@Test
+	public void testHubVersionApiMissing() throws Exception {
+		final HubIntRestService service = getMockedService("2.0.1");
+		final ResourceException cause = new ResourceException(Status.CLIENT_ERROR_NOT_FOUND);
+		final BDRestException exception = new BDRestException("", cause, null);
+		Mockito.when(service.getHubVersion()).thenThrow(exception);
 
-    }
+		final HubSupportHelper supportHelper = new HubSupportHelper();
+		final TestLogger logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-    @Test
-    public void testHubVersionApiRestFailure() throws Exception {
-        HubIntRestService service = getMockedService("2.0.1");
-        ResourceException cause = new ResourceException(Status.CLIENT_ERROR_PAYMENT_REQUIRED);
-        final String errorMessage = "error";
-        BDRestException exception = new BDRestException(errorMessage, cause, null);
-        Mockito.when(service.getHubVersion()).thenThrow(exception);
+		for (final HubCapabilitiesEnum value : HubCapabilitiesEnum.values()) {
+			assertFalse(supportHelper.hasCapability(value));
+		}
+	}
 
-        HubSupportHelper supportHelper = new HubSupportHelper();
-        TestLogger logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+	@Test
+	public void testHubVersionApiRestFailure() throws Exception {
+		final HubIntRestService service = getMockedService("2.0.1");
+		final ResourceException cause = new ResourceException(Status.CLIENT_ERROR_PAYMENT_REQUIRED);
+		final String errorMessage = "error";
+		final BDRestException exception = new BDRestException(errorMessage, cause, null);
+		Mockito.when(service.getHubVersion()).thenThrow(exception);
 
-        assertTrue(!supportHelper.isJreProvidedSupport());
-        assertTrue(!supportHelper.isPolicyApiSupport());
+		final HubSupportHelper supportHelper = new HubSupportHelper();
+		final TestLogger logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-        assertTrue(logger.getOutputString().contains(errorMessage));
-        assertTrue(logger.getOutputString().contains(Status.CLIENT_ERROR_PAYMENT_REQUIRED.getReasonPhrase()));
-    }
+		for (final HubCapabilitiesEnum value : HubCapabilitiesEnum.values()) {
+			assertFalse(supportHelper.hasCapability(value));
+		}
 
-    @Test
-    public void testHubVersionApiRestFailureDifferentEror() throws Exception {
-        HubIntRestService service = getMockedService("2.0.1");
-        Exception cause = new Exception();
-        final String errorMessage = "error";
-        BDRestException exception = new BDRestException(errorMessage, cause, null);
-        Mockito.when(service.getHubVersion()).thenThrow(exception);
+		assertTrue(logger.getOutputString().contains(errorMessage));
+		assertTrue(logger.getOutputString().contains(Status.CLIENT_ERROR_PAYMENT_REQUIRED.getReasonPhrase()));
+	}
 
-        HubSupportHelper supportHelper = new HubSupportHelper();
-        TestLogger logger = new TestLogger();
-        supportHelper.checkHubSupport(service, logger);
+	@Test
+	public void testHubVersionApiRestFailureDifferentEror() throws Exception {
+		final HubIntRestService service = getMockedService("2.0.1");
+		final Exception cause = new Exception();
+		final String errorMessage = "error";
+		final BDRestException exception = new BDRestException(errorMessage, cause, null);
+		Mockito.when(service.getHubVersion()).thenThrow(exception);
 
-        assertTrue(!supportHelper.isJreProvidedSupport());
-        assertTrue(!supportHelper.isPolicyApiSupport());
-        assertTrue(logger.getOutputString().contains(errorMessage));
-    }
+		final HubSupportHelper supportHelper = new HubSupportHelper();
+		final TestLogger logger = new TestLogger();
+		supportHelper.checkHubSupport(service, logger);
 
-    @Test
-    public void testGetLinuxCLIWrapperLink() throws Exception {
-        assertEquals("testUrl/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("testUrl"));
-        assertEquals("testUrl/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("testUrl/"));
-        assertEquals("http://testSite/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("http://testSite/"));
-        assertEquals("http://testSite/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("http://testSite"));
+		for (final HubCapabilitiesEnum value : HubCapabilitiesEnum.values()) {
+			assertFalse(supportHelper.hasCapability(value));
+		}
+		assertTrue(logger.getOutputString().contains(errorMessage));
+	}
 
-        try {
-            HubSupportHelper.getLinuxCLIWrapperLink(" ");
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
+	@Test
+	public void testGetLinuxCLIWrapperLink() throws Exception {
+		assertEquals("testUrl/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("testUrl"));
+		assertEquals("testUrl/download/scan.cli.zip", HubSupportHelper.getLinuxCLIWrapperLink("testUrl/"));
+		assertEquals("http://testSite/download/scan.cli.zip",
+				HubSupportHelper.getLinuxCLIWrapperLink("http://testSite/"));
+		assertEquals("http://testSite/download/scan.cli.zip",
+				HubSupportHelper.getLinuxCLIWrapperLink("http://testSite"));
 
-        try {
-            HubSupportHelper.getLinuxCLIWrapperLink(null);
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
-    }
+		try {
+			HubSupportHelper.getLinuxCLIWrapperLink(" ");
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
 
-    @Test
-    public void testGetWindowsCLIWrapperLink() throws Exception {
-        assertEquals("testUrl/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("testUrl"));
-        assertEquals("testUrl/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("testUrl/"));
-        assertEquals("http://testSite/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("http://testSite/"));
-        assertEquals("http://testSite/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("http://testSite"));
+		try {
+			HubSupportHelper.getLinuxCLIWrapperLink(null);
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
+	}
 
-        try {
-            HubSupportHelper.getWindowsCLIWrapperLink(" ");
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
+	@Test
+	public void testGetWindowsCLIWrapperLink() throws Exception {
+		assertEquals("testUrl/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("testUrl"));
+		assertEquals("testUrl/download/scan.cli-windows.zip", HubSupportHelper.getWindowsCLIWrapperLink("testUrl/"));
+		assertEquals("http://testSite/download/scan.cli-windows.zip",
+				HubSupportHelper.getWindowsCLIWrapperLink("http://testSite/"));
+		assertEquals("http://testSite/download/scan.cli-windows.zip",
+				HubSupportHelper.getWindowsCLIWrapperLink("http://testSite"));
 
-        try {
-            HubSupportHelper.getWindowsCLIWrapperLink(null);
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
-    }
+		try {
+			HubSupportHelper.getWindowsCLIWrapperLink(" ");
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
 
-    @Test
-    public void testGetOSXCLIWrapperLink() throws Exception {
-        assertEquals("testUrl/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("testUrl"));
-        assertEquals("testUrl/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("testUrl/"));
-        assertEquals("http://testSite/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("http://testSite/"));
-        assertEquals("http://testSite/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("http://testSite"));
+		try {
+			HubSupportHelper.getWindowsCLIWrapperLink(null);
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
+	}
 
-        try {
-            HubSupportHelper.getOSXCLIWrapperLink(" ");
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
+	@Test
+	public void testGetOSXCLIWrapperLink() throws Exception {
+		assertEquals("testUrl/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("testUrl"));
+		assertEquals("testUrl/download/scan.cli-macosx.zip", HubSupportHelper.getOSXCLIWrapperLink("testUrl/"));
+		assertEquals("http://testSite/download/scan.cli-macosx.zip",
+				HubSupportHelper.getOSXCLIWrapperLink("http://testSite/"));
+		assertEquals("http://testSite/download/scan.cli-macosx.zip",
+				HubSupportHelper.getOSXCLIWrapperLink("http://testSite"));
 
-        try {
-            HubSupportHelper.getOSXCLIWrapperLink(null);
-        } catch (Exception e) {
-            assertTrue(e instanceof IllegalArgumentException);
-            assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
-        }
-    }
+		try {
+			HubSupportHelper.getOSXCLIWrapperLink(" ");
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
+
+		try {
+			HubSupportHelper.getOSXCLIWrapperLink(null);
+		} catch (final Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+			assertEquals("You must provide a valid Hub URL in order to get the correct link.", e.getMessage());
+		}
+	}
 
 }

--- a/src/test/java/com/blackducksoftware/integration/hub/cli/CLILocationTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/cli/CLILocationTest.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.cli;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/blackducksoftware/integration/hub/item/HubItemTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/item/HubItemTest.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.item;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/blackducksoftware/integration/hub/policy/api/PolicyRuleTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/policy/api/PolicyRuleTest.java
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *******************************************************************************/
 package com.blackducksoftware.integration.hub.policy.api;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Changes to implement http Post methods in Rest Connection

This is to allow the maven plugin to be able to upload the common BOM file format.
Updated the hub support helper to use an enum for capabilities of the Hub. 
Convert the create methods in HubIntRestService to use the post methods in RestConnection.