### PR TITLE
Make Rest Connection abstract and add a CredentialsRestConnection

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/HubIntRestService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/HubIntRestService.java
@@ -124,14 +124,6 @@ public class HubIntRestService {
 	 * @deprecated moved to RestConnection.
 	 */
 	@Deprecated
-	public HubIntRestService(final String baseUrl) throws URISyntaxException {
-		this(new RestConnection(baseUrl));
-	}
-
-	/**
-	 * @deprecated moved to RestConnection.
-	 */
-	@Deprecated
 	public void setTimeout(final int timeout) {
 		getRestConnection().setTimeout(timeout);
 	}

--- a/src/main/java/com/blackducksoftware/integration/hub/api/notification/NotificationRestService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/notification/NotificationRestService.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.restlet.data.Method;
 
@@ -70,7 +71,7 @@ public class NotificationRestService extends HubItemRestService<NotificationItem
 	public List<NotificationItem> getAllNotifications(final Date startDate, final Date endDate)
 			throws IOException, URISyntaxException, BDRestException {
 		final SimpleDateFormat sdf = new SimpleDateFormat(RestConnection.JSON_DATE_FORMAT);
-
+		sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 		final String startDateString = sdf.format(startDate);
 		final String endDateString = sdf.format(endDate);
 

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
@@ -1,0 +1,39 @@
+package com.blackducksoftware.integration.hub.rest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.restlet.Context;
+import org.restlet.resource.ClientResource;
+
+import com.blackducksoftware.integration.exception.EncryptionException;
+import com.blackducksoftware.integration.hub.exception.BDRestException;
+import com.blackducksoftware.integration.hub.global.HubProxyInfo;
+import com.blackducksoftware.integration.hub.global.HubServerConfig;
+
+public class CredentialsRestConnection extends RestConnection {
+
+	public CredentialsRestConnection(final HubServerConfig hubServerConfig)
+			throws IllegalArgumentException, URISyntaxException, BDRestException, EncryptionException {
+		super();
+		setBaseUrl(hubServerConfig.getHubUrl().toString());
+		final HubProxyInfo proxyInfo = hubServerConfig.getProxyInfo();
+		if (proxyInfo.shouldUseProxyForUrl(hubServerConfig.getHubUrl())) {
+			setProxyProperties(proxyInfo);
+		}
+		setTimeout(hubServerConfig.getTimeout());
+		final String userName = hubServerConfig.getGlobalCredentials().getUsername();
+		final String password = hubServerConfig.getGlobalCredentials().getEncryptedPassword();
+		if (StringUtils.isNotBlank(userName) && StringUtils.isNotBlank(password)) {
+			setCookies(hubServerConfig.getGlobalCredentials().getUsername(),
+					hubServerConfig.getGlobalCredentials().getDecryptedPassword());
+		}
+	}
+
+	@Override
+	public ClientResource createClientResource(final Context context, final String providedUrl)
+			throws URISyntaxException {
+		return new ClientResource(context, new URI(providedUrl));
+	}
+}

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
@@ -23,11 +23,11 @@ public class CredentialsRestConnection extends RestConnection {
 			setProxyProperties(proxyInfo);
 		}
 		setTimeout(hubServerConfig.getTimeout());
-		final String userName = hubServerConfig.getGlobalCredentials().getUsername();
-		final String password = hubServerConfig.getGlobalCredentials().getEncryptedPassword();
-		if (StringUtils.isNotBlank(userName) && StringUtils.isNotBlank(password)) {
-			setCookies(hubServerConfig.getGlobalCredentials().getUsername(),
-					hubServerConfig.getGlobalCredentials().getDecryptedPassword());
+		final String username = hubServerConfig.getGlobalCredentials().getUsername();
+		String password = hubServerConfig.getGlobalCredentials().getEncryptedPassword();
+		if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
+			password = hubServerConfig.getGlobalCredentials().getDecryptedPassword();
+			setCookies(username, password);
 		}
 	}
 

--- a/src/test/java/com/blackducksoftware/integration/hub/cli/CLILocationTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/cli/CLILocationTest.java
@@ -26,8 +26,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,7 +39,10 @@ import org.mockito.Mockito;
 
 import com.blackducksoftware.integration.hub.HubIntRestService;
 import com.blackducksoftware.integration.hub.HubSupportHelper;
-import com.blackducksoftware.integration.hub.rest.RestConnection;
+import com.blackducksoftware.integration.hub.global.HubCredentials;
+import com.blackducksoftware.integration.hub.global.HubProxyInfo;
+import com.blackducksoftware.integration.hub.global.HubServerConfig;
+import com.blackducksoftware.integration.hub.rest.CredentialsRestConnection;
 
 public class CLILocationTest {
 	@Rule
@@ -44,6 +50,27 @@ public class CLILocationTest {
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
+
+	private HubServerConfig hubServerConfig;
+
+	@Before
+	public void initTest() throws MalformedURLException {
+		final HubProxyInfo proxyInfo = Mockito.mock(HubProxyInfo.class);
+		Mockito.when(proxyInfo.getUsername()).thenReturn("");
+		Mockito.when(proxyInfo.getEncryptedPassword()).thenReturn("");
+		Mockito.when(proxyInfo.getActualPasswordLength()).thenReturn(0);
+
+		final HubCredentials credentials = Mockito.mock(HubCredentials.class);
+		Mockito.when(credentials.getUsername()).thenReturn("");
+		Mockito.when(credentials.getActualPasswordLength()).thenReturn(0);
+		Mockito.when(credentials.getEncryptedPassword()).thenReturn("");
+		hubServerConfig = Mockito.mock(HubServerConfig.class);
+
+		Mockito.when(hubServerConfig.getHubUrl()).thenReturn(new URL("http://test-hub-server"));
+		Mockito.when(hubServerConfig.getTimeout()).thenReturn(120);
+		Mockito.when(hubServerConfig.getGlobalCredentials()).thenReturn(credentials);
+		Mockito.when(hubServerConfig.getProxyInfo()).thenReturn(proxyInfo);
+	}
 
 	@Test
 	public void testConstructorNull() throws Exception {
@@ -71,7 +98,7 @@ public class CLILocationTest {
 
 		final File directoryToInstallTo = folder.newFolder();
 		final CLILocation cliLocation = new CLILocation(directoryToInstallTo);
-		HubIntRestService restService = new HubIntRestService(new RestConnection(baseUrl));
+		HubIntRestService restService = new HubIntRestService(new CredentialsRestConnection(hubServerConfig));
 		restService = Mockito.spy(restService);
 		Mockito.doReturn("3.0.1").when(restService).getHubVersion();
 
@@ -98,7 +125,7 @@ public class CLILocationTest {
 
 		final File directoryToInstallTo = folder.newFolder();
 		final CLILocation cliLocation = new CLILocation(directoryToInstallTo);
-		HubIntRestService restService = new HubIntRestService(new RestConnection(baseUrl));
+		HubIntRestService restService = new HubIntRestService(new CredentialsRestConnection(hubServerConfig));
 		restService = Mockito.spy(restService);
 		Mockito.doReturn("2.4.0").when(restService).getHubVersion();
 

--- a/src/test/java/com/blackducksoftware/integration/hub/polling/HubEventPollingTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/polling/HubEventPollingTest.java
@@ -26,10 +26,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -47,7 +50,11 @@ import com.blackducksoftware.integration.hub.api.scan.ScanStatus;
 import com.blackducksoftware.integration.hub.api.scan.ScanSummaryItem;
 import com.blackducksoftware.integration.hub.api.scan.ScanSummaryRestService;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
+import com.blackducksoftware.integration.hub.global.HubCredentials;
+import com.blackducksoftware.integration.hub.global.HubProxyInfo;
+import com.blackducksoftware.integration.hub.global.HubServerConfig;
 import com.blackducksoftware.integration.hub.meta.MetaInformation;
+import com.blackducksoftware.integration.hub.rest.CredentialsRestConnection;
 import com.blackducksoftware.integration.hub.rest.RestConnection;
 import com.blackducksoftware.integration.test.TestLogger;
 import com.google.gson.Gson;
@@ -59,6 +66,27 @@ public class HubEventPollingTest {
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
+
+	private HubServerConfig hubServerConfig;
+
+	@Before
+	public void initTest() throws MalformedURLException {
+		final HubProxyInfo proxyInfo = Mockito.mock(HubProxyInfo.class);
+		Mockito.when(proxyInfo.getUsername()).thenReturn("");
+		Mockito.when(proxyInfo.getEncryptedPassword()).thenReturn("");
+		Mockito.when(proxyInfo.getActualPasswordLength()).thenReturn(0);
+
+		final HubCredentials credentials = Mockito.mock(HubCredentials.class);
+		Mockito.when(credentials.getUsername()).thenReturn("");
+		Mockito.when(credentials.getActualPasswordLength()).thenReturn(0);
+		Mockito.when(credentials.getEncryptedPassword()).thenReturn("");
+		hubServerConfig = Mockito.mock(HubServerConfig.class);
+
+		Mockito.when(hubServerConfig.getHubUrl()).thenReturn(new URL("http://fakeURL"));
+		Mockito.when(hubServerConfig.getTimeout()).thenReturn(120);
+		Mockito.when(hubServerConfig.getGlobalCredentials()).thenReturn(credentials);
+		Mockito.when(hubServerConfig.getProxyInfo()).thenReturn(proxyInfo);
+	}
 
 	private void writeScanStatusToFile(final ScanSummaryItem status, final File file) throws IOException {
 		final Gson gson = new GsonBuilder().create();
@@ -92,7 +120,7 @@ public class HubEventPollingTest {
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString()))
 				.thenReturn(new ScanSummaryItem(ScanStatus.COMPLETE, null, null, null, _meta));
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		final HubIntRestService restService = new HubIntRestService(restConnection);
 		restService.setScanSummaryRestService(scanSummaryRestService);
 
@@ -145,7 +173,7 @@ public class HubEventPollingTest {
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString()))
 				.thenReturn(new ScanSummaryItem(ScanStatus.BUILDING_BOM, null, null, null, _meta));
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		final HubIntRestService restService = new HubIntRestService(restConnection);
 		restService.setScanSummaryRestService(scanSummaryRestService);
 
@@ -189,7 +217,7 @@ public class HubEventPollingTest {
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString()))
 				.thenReturn(new ScanSummaryItem(ScanStatus.ERROR, null, null, null, _meta));
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		final HubIntRestService restService = new HubIntRestService(restConnection);
 		restService.setScanSummaryRestService(scanSummaryRestService);
 

--- a/src/test/java/com/blackducksoftware/integration/hub/report/api/RiskReportGeneratorTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/report/api/RiskReportGeneratorTest.java
@@ -26,10 +26,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -55,8 +58,12 @@ import com.blackducksoftware.integration.hub.api.scan.ScanSummaryItem;
 import com.blackducksoftware.integration.hub.api.scan.ScanSummaryRestService;
 import com.blackducksoftware.integration.hub.api.version.ReleaseItem;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
+import com.blackducksoftware.integration.hub.global.HubCredentials;
+import com.blackducksoftware.integration.hub.global.HubProxyInfo;
+import com.blackducksoftware.integration.hub.global.HubServerConfig;
 import com.blackducksoftware.integration.hub.meta.MetaInformation;
 import com.blackducksoftware.integration.hub.meta.MetaLink;
+import com.blackducksoftware.integration.hub.rest.CredentialsRestConnection;
 import com.blackducksoftware.integration.hub.rest.RestConnection;
 import com.blackducksoftware.integration.test.TestLogger;
 
@@ -67,6 +74,27 @@ public class RiskReportGeneratorTest {
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 
+	private HubServerConfig hubServerConfig;
+
+	@Before
+	public void initTest() throws MalformedURLException {
+		final HubProxyInfo proxyInfo = Mockito.mock(HubProxyInfo.class);
+		Mockito.when(proxyInfo.getUsername()).thenReturn("");
+		Mockito.when(proxyInfo.getEncryptedPassword()).thenReturn("");
+		Mockito.when(proxyInfo.getActualPasswordLength()).thenReturn(0);
+
+		final HubCredentials credentials = Mockito.mock(HubCredentials.class);
+		Mockito.when(credentials.getUsername()).thenReturn("");
+		Mockito.when(credentials.getActualPasswordLength()).thenReturn(0);
+		Mockito.when(credentials.getEncryptedPassword()).thenReturn("");
+		hubServerConfig = Mockito.mock(HubServerConfig.class);
+
+		Mockito.when(hubServerConfig.getHubUrl()).thenReturn(new URL("http://fakeURL"));
+		Mockito.when(hubServerConfig.getTimeout()).thenReturn(120);
+		Mockito.when(hubServerConfig.getGlobalCredentials()).thenReturn(credentials);
+		Mockito.when(hubServerConfig.getProxyInfo()).thenReturn(proxyInfo);
+	}
+
 	@Test
 	public void generateReportWithScanStatusFiles() throws Exception {
 		final ScanSummaryRestService scanSummaryRestService = Mockito.mock(ScanSummaryRestService.class);
@@ -76,7 +104,7 @@ public class RiskReportGeneratorTest {
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString()))
 				.thenReturn(new ScanSummaryItem(ScanStatus.COMPLETE, null, null, null, _meta));
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		HubIntRestService service = new HubIntRestService(restConnection);
 		service.setScanSummaryRestService(scanSummaryRestService);
 		service = Mockito.spy(service);
@@ -146,7 +174,8 @@ public class RiskReportGeneratorTest {
 		final ScanSummaryItem statusComplete = new ScanSummaryItem(ScanStatus.COMPLETE, null, null, null, _meta);
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString())).thenReturn(statusComplete);
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
+		;
 		HubIntRestService service = new HubIntRestService(restConnection);
 		service.setScanSummaryRestService(scanSummaryRestService);
 		service = Mockito.spy(service);
@@ -205,7 +234,7 @@ public class RiskReportGeneratorTest {
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString()))
 				.thenReturn(new ScanSummaryItem(ScanStatus.COMPLETE, null, null, null, _meta));
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		HubIntRestService service = new HubIntRestService(restConnection);
 		service.setScanSummaryRestService(scanSummaryRestService);
 		service = Mockito.spy(service);
@@ -260,7 +289,7 @@ public class RiskReportGeneratorTest {
 		final ScanSummaryItem statusBuilding = new ScanSummaryItem(ScanStatus.BUILDING_BOM, null, null, null, _meta);
 		Mockito.when(scanSummaryRestService.getItem(Mockito.anyString())).thenReturn(statusBuilding);
 
-		final RestConnection restConnection = new RestConnection("FakeHubUrl");
+		final RestConnection restConnection = new CredentialsRestConnection(hubServerConfig);
 		HubIntRestService service = new HubIntRestService(restConnection);
 		service.setScanSummaryRestService(scanSummaryRestService);
 		service = Mockito.spy(service);
@@ -298,8 +327,7 @@ public class RiskReportGeneratorTest {
 
 	@Test
 	public void generateReportWithCodeLocations() throws Exception {
-		HubIntRestService service = new HubIntRestService("FakeHubUrl");
-		service = Mockito.spy(service);
+		final HubIntRestService service = Mockito.mock(HubIntRestService.class);
 
 		final String hostName = "FakeHostName";
 
@@ -412,8 +440,7 @@ public class RiskReportGeneratorTest {
 		exception.expect(HubIntegrationException.class);
 		exception.expectMessage("Could not find content link for the report at : ");
 
-		HubIntRestService service = new HubIntRestService("FakeHubUrl");
-		service = Mockito.spy(service);
+		final HubIntRestService service = Mockito.mock(HubIntRestService.class);
 
 		final String hostName = "FakeHostName";
 
@@ -516,8 +543,7 @@ public class RiskReportGeneratorTest {
 		exception.expect(HubIntegrationException.class);
 		exception.expectMessage("The Report has not finished generating in : ");
 
-		HubIntRestService service = new HubIntRestService("FakeHubUrl");
-		service = Mockito.spy(service);
+		final HubIntRestService service = Mockito.mock(HubIntRestService.class);
 
 		final String hostName = "FakeHostName";
 
@@ -616,8 +642,7 @@ public class RiskReportGeneratorTest {
 		exception.expect(HubIntegrationException.class);
 		exception.expectMessage("The Bom has not finished updating from the scan within the specified wait time : ");
 
-		HubIntRestService service = new HubIntRestService("FakeHubUrl");
-		service = Mockito.spy(service);
+		final HubIntRestService service = Mockito.mock(HubIntRestService.class);
 
 		final String hostName = "FakeHostName";
 


### PR DESCRIPTION
Make the Rest Connection class abstract in order to remove the need for
a HubServerConfig object to be populated correctly to create the rest
connection.  Create a CredentialsRestConnection that will take the
HubServerConfig object in the constructor and initialize the
RestConnection object. If the username and password are empty then do
not call the setCookies method in the constructor.