### PR TITLE
Sb rest connection handle request hang

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/CredentialsRestConnection.java
@@ -32,12 +32,18 @@ import com.blackducksoftware.integration.exception.EncryptionException;
 import com.blackducksoftware.integration.hub.exception.BDRestException;
 import com.blackducksoftware.integration.hub.global.HubProxyInfo;
 import com.blackducksoftware.integration.hub.global.HubServerConfig;
+import com.blackducksoftware.integration.log.IntLogger;
 
 public class CredentialsRestConnection extends RestConnection {
 
     public CredentialsRestConnection(final HubServerConfig hubServerConfig)
             throws IllegalArgumentException, URISyntaxException, BDRestException, EncryptionException {
-        super();
+        this(null, hubServerConfig);
+    }
+    
+    public CredentialsRestConnection(final IntLogger logger, final HubServerConfig hubServerConfig)
+            throws IllegalArgumentException, URISyntaxException, BDRestException, EncryptionException {
+        super(logger);
         setBaseUrl(hubServerConfig.getHubUrl().toString());
         final HubProxyInfo proxyInfo = hubServerConfig.getProxyInfo();
         if (proxyInfo.shouldUseProxyForUrl(hubServerConfig.getHubUrl())) {

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -49,7 +49,6 @@ import org.restlet.data.Cookie;
 import org.restlet.data.CookieSetting;
 import org.restlet.data.MediaType;
 import org.restlet.data.Method;
-import org.restlet.data.Parameter;
 import org.restlet.data.Protocol;
 import org.restlet.engine.header.HeaderConstants;
 import org.restlet.representation.Representation;
@@ -131,26 +130,8 @@ public abstract class RestConnection {
         // would need to be divided by the number of hub instances.
 
         logMessage(LogLevel.DEBUG, "Setting maxConnectionsPerHost and maxTotalConnections on client context");
-        // TODO TEMP
-        if (isDebugLogging()) {
-            Series<Parameter> parameters = client.getContext().getParameters();
-            logMessage(LogLevel.DEBUG, "createClient() Parameters: Before:");
-            for (Parameter param : parameters) {
-                logMessage(LogLevel.DEBUG, "\tcreateClient() before setting connections: Parameter: " + param.getName() + " = " + param.getValue());
-            }
-        }
-
         client.getContext().getParameters().set("maxConnectionsPerHost", "100");
         client.getContext().getParameters().set("maxTotalConnections", "100");
-
-        // TODO TEMP
-        if (isDebugLogging()) {
-            Series<Parameter> parameters = client.getContext().getParameters();
-            logMessage(LogLevel.DEBUG, "createClient() Parameters: After:");
-            for (Parameter param : parameters) {
-                logMessage(LogLevel.DEBUG, "\tcreateClient() after setting connections: Parameter: " + param.getName() + " = " + param.getValue());
-            }
-        }
 
         return client;
     }
@@ -180,28 +161,9 @@ public abstract class RestConnection {
         // the User sets the timeout in seconds, so we translate to ms
         final String stringTimeout = String.valueOf(timeout * 1000);
         logMessage(LogLevel.DEBUG, "Setting socketTimeout, socketConnectTimeoutMs, and readTimeout to: " + stringTimeout + " on client context");
-
-        // TODO TEMP
-        if (isDebugLogging()) {
-            Series<Parameter> parameters = client.getContext().getParameters();
-            logMessage(LogLevel.DEBUG, "Parameters: Before:");
-            for (Parameter param : parameters) {
-                logMessage(LogLevel.DEBUG, "\tsetClientTimeout() before setting timeouts: Parameter: " + param.getName() + " = " + param.getValue());
-            }
-        }
-
         client.getContext().getParameters().set("socketTimeout", stringTimeout);
         client.getContext().getParameters().set("socketConnectTimeoutMs", stringTimeout);
         client.getContext().getParameters().set("readTimeout", stringTimeout);
-
-        // TODO TEMP
-        if (isDebugLogging()) {
-            Series<Parameter> parameters = client.getContext().getParameters();
-            logMessage(LogLevel.DEBUG, "Parameters: After:");
-            for (Parameter param : parameters) {
-                logMessage(LogLevel.DEBUG, "\tsetClientTimeout() after setting timeouts: Parameter: " + param.getName() + " = " + param.getValue());
-            }
-        }
     }
 
     public String getBaseUrl() {

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -49,6 +49,7 @@ import org.restlet.data.Cookie;
 import org.restlet.data.CookieSetting;
 import org.restlet.data.MediaType;
 import org.restlet.data.Method;
+import org.restlet.data.Parameter;
 import org.restlet.data.Protocol;
 import org.restlet.engine.header.HeaderConstants;
 import org.restlet.representation.Representation;
@@ -105,10 +106,19 @@ public abstract class RestConnection {
     }
 
     public RestConnection() {
+        this(null);
+    }
+
+    public RestConnection(final IntLogger logger) {
+        if (logger != null) {
+            setLogger(logger);
+        }
         client = createClient();
+        setClientTimeout(timeout); // just in case setTimeout() is never called
     }
 
     private Client createClient() {
+        logMessage(LogLevel.DEBUG, "createClient()");
         final Context context = new Context();
         final List<Protocol> protocolList = new ArrayList<>();
         protocolList.add(Protocol.HTTP);
@@ -119,8 +129,28 @@ public abstract class RestConnection {
         // be equal to the maxTotalConnections. If this rest connection object
         // connects to more than one hub instance then the maxConnectionsPerHost
         // would need to be divided by the number of hub instances.
-        client.getContext().getParameters().add("maxConnectionsPerHost", "100");
-        client.getContext().getParameters().add("maxTotalConnections", "100");
+
+        logMessage(LogLevel.DEBUG, "Setting maxConnectionsPerHost and maxTotalConnections on client context");
+        // TODO TEMP
+        if (isDebugLogging()) {
+            Series<Parameter> parameters = client.getContext().getParameters();
+            logMessage(LogLevel.DEBUG, "createClient() Parameters: Before:");
+            for (Parameter param : parameters) {
+                logMessage(LogLevel.DEBUG, "\tcreateClient() before setting connections: Parameter: " + param.getName() + " = " + param.getValue());
+            }
+        }
+
+        client.getContext().getParameters().set("maxConnectionsPerHost", "100");
+        client.getContext().getParameters().set("maxTotalConnections", "100");
+
+        // TODO TEMP
+        if (isDebugLogging()) {
+            Series<Parameter> parameters = client.getContext().getParameters();
+            logMessage(LogLevel.DEBUG, "createClient() Parameters: After:");
+            for (Parameter param : parameters) {
+                logMessage(LogLevel.DEBUG, "\tcreateClient() after setting connections: Parameter: " + param.getName() + " = " + param.getValue());
+            }
+        }
 
         return client;
     }
@@ -138,20 +168,40 @@ public abstract class RestConnection {
     }
 
     public void setTimeout(final int timeout) {
-        if (timeout == 0) {
-            throw new IllegalArgumentException("Can not set the timeout to zero.");
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Timeout must be non-negative.");
         }
         this.timeout = timeout;
         setClientTimeout(this.timeout);
     }
 
     private void setClientTimeout(final int timeout) {
+        this.timeout = timeout;
         // the User sets the timeout in seconds, so we translate to ms
         final String stringTimeout = String.valueOf(timeout * 1000);
+        logMessage(LogLevel.DEBUG, "Setting socketTimeout, socketConnectTimeoutMs, and readTimeout to: " + stringTimeout + " on client context");
 
-        client.getContext().getParameters().add("socketTimeout", stringTimeout);
-        client.getContext().getParameters().add("socketConnectTimeoutMs", stringTimeout);
-        client.getContext().getParameters().add("readTimeout", stringTimeout);
+        // TODO TEMP
+        if (isDebugLogging()) {
+            Series<Parameter> parameters = client.getContext().getParameters();
+            logMessage(LogLevel.DEBUG, "Parameters: Before:");
+            for (Parameter param : parameters) {
+                logMessage(LogLevel.DEBUG, "\tsetClientTimeout() before setting timeouts: Parameter: " + param.getName() + " = " + param.getValue());
+            }
+        }
+
+        client.getContext().getParameters().set("socketTimeout", stringTimeout);
+        client.getContext().getParameters().set("socketConnectTimeoutMs", stringTimeout);
+        client.getContext().getParameters().set("readTimeout", stringTimeout);
+
+        // TODO TEMP
+        if (isDebugLogging()) {
+            Series<Parameter> parameters = client.getContext().getParameters();
+            logMessage(LogLevel.DEBUG, "Parameters: After:");
+            for (Parameter param : parameters) {
+                logMessage(LogLevel.DEBUG, "\tsetClientTimeout() after setting timeouts: Parameter: " + param.getName() + " = " + param.getValue());
+            }
+        }
     }
 
     public String getBaseUrl() {
@@ -420,7 +470,7 @@ public abstract class RestConnection {
     }
 
     public void handleRequest(final ClientResource resource) throws BDRestException {
-        final boolean debugLogging = logger != null && logger.getLogLevel() == LogLevel.TRACE;
+        final boolean debugLogging = isDebugLogging();
         if (debugLogging) {
             logMessage(LogLevel.TRACE, "Resource : " + resource.toString());
             logRestletRequestOrResponse(resource.getRequest());
@@ -452,12 +502,16 @@ public abstract class RestConnection {
         }
     }
 
+    private boolean isDebugLogging() {
+        return logger != null && logger.getLogLevel() == LogLevel.TRACE;
+    }
+
     public String readResponseAsString(final Response response) throws IOException {
         return response.getEntityAsText();
     }
 
     private void logRestletRequestOrResponse(final Message requestOrResponse) {
-        if (logger != null && logger.getLogLevel() == LogLevel.TRACE) {
+        if (isDebugLogging()) {
             final String requestOrResponseName = requestOrResponse.getClass().getSimpleName();
             logMessage(LogLevel.TRACE, requestOrResponseName + " : " + requestOrResponse.toString());
 

--- a/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/rest/RestConnection.java
@@ -113,7 +113,7 @@ public abstract class RestConnection {
             setLogger(logger);
         }
         client = createClient();
-        setClientTimeout(timeout); // just in case setTimeout() is never called
+        setTimeout(timeout); // just in case setTimeout() is never called
     }
 
     private Client createClient() {
@@ -152,11 +152,6 @@ public abstract class RestConnection {
         if (timeout < 0) {
             throw new IllegalArgumentException("Timeout must be non-negative.");
         }
-        this.timeout = timeout;
-        setClientTimeout(this.timeout);
-    }
-
-    private void setClientTimeout(final int timeout) {
         this.timeout = timeout;
         // the User sets the timeout in seconds, so we translate to ms
         final String stringTimeout = String.valueOf(timeout * 1000);

--- a/src/test/java/com/blackducksoftware/integration/hub/rest/RestConnectionTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/rest/RestConnectionTest.java
@@ -29,7 +29,14 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.blackducksoftware.integration.exception.EncryptionException;
+import com.blackducksoftware.integration.hub.builder.HubServerConfigBuilder;
+import com.blackducksoftware.integration.hub.exception.BDRestException;
+import com.blackducksoftware.integration.hub.global.HubServerConfig;
 import com.blackducksoftware.integration.hub.util.HubUrlParser;
+import com.blackducksoftware.integration.log.IntLogger;
+import com.blackducksoftware.integration.log.LogLevel;
+import com.blackducksoftware.integration.test.TestLogger;
 
 public class RestConnectionTest {
 
@@ -75,5 +82,19 @@ public class RestConnectionTest {
         final String projectVersionUrl = urlPrefix + projectVersionRelativeUrl;
 
         assertEquals(projectVersionRelativeUrl, HubUrlParser.getRelativeUrl(projectVersionUrl));
+    }
+    
+    // TODO this is an integration test
+    @Test
+    public void testConnectionParameters() throws IllegalArgumentException, URISyntaxException, BDRestException, EncryptionException {
+        IntLogger logger = new TestLogger();
+        logger.setLogLevel(LogLevel.TRACE);
+        HubServerConfigBuilder builder = new HubServerConfigBuilder();
+        builder.setHubUrl("https://integration-hub.blackducksoftware.com:8443");
+        builder.setUsername("sysadmin");
+        builder.setPassword("blackduck");
+        builder.setTimeout(33);
+        HubServerConfig config = builder.build();
+        RestConnection conn = new CredentialsRestConnection(logger , config);
     }
 }

--- a/src/test/java/com/blackducksoftware/integration/hub/rest/RestConnectionTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/rest/RestConnectionTest.java
@@ -29,14 +29,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.blackducksoftware.integration.exception.EncryptionException;
-import com.blackducksoftware.integration.hub.builder.HubServerConfigBuilder;
-import com.blackducksoftware.integration.hub.exception.BDRestException;
-import com.blackducksoftware.integration.hub.global.HubServerConfig;
 import com.blackducksoftware.integration.hub.util.HubUrlParser;
-import com.blackducksoftware.integration.log.IntLogger;
-import com.blackducksoftware.integration.log.LogLevel;
-import com.blackducksoftware.integration.test.TestLogger;
 
 public class RestConnectionTest {
 
@@ -82,19 +75,5 @@ public class RestConnectionTest {
         final String projectVersionUrl = urlPrefix + projectVersionRelativeUrl;
 
         assertEquals(projectVersionRelativeUrl, HubUrlParser.getRelativeUrl(projectVersionUrl));
-    }
-    
-    // TODO this is an integration test
-    @Test
-    public void testConnectionParameters() throws IllegalArgumentException, URISyntaxException, BDRestException, EncryptionException {
-        IntLogger logger = new TestLogger();
-        logger.setLogLevel(LogLevel.TRACE);
-        HubServerConfigBuilder builder = new HubServerConfigBuilder();
-        builder.setHubUrl("https://integration-hub.blackducksoftware.com:8443");
-        builder.setUsername("sysadmin");
-        builder.setPassword("blackduck");
-        builder.setTimeout(33);
-        HubServerConfig config = builder.build();
-        RestConnection conn = new CredentialsRestConnection(logger , config);
     }
 }


### PR DESCRIPTION
RestConnection:
1. Use getParameters().set() rather than add(), in case timeout is changed after being set.
2. Call setTimeout() from constructor, in case user doesn't set timeout (adding this will change the default behavior from infinite timeout to default timeout).
3. New constructor that takes a logger