### PR TITLE
Sb separate affected project version from project version

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/api/item/MetaService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/item/MetaService.java
@@ -93,17 +93,27 @@ public class MetaService {
         this.hubRequestFactory = hubRequestFactory;
     }
 
+    // This will be replaced soon with a getFirstLink() method
+    @Deprecated
     public String getLink(final HubItem item, final String linkKey) throws HubIntegrationException {
         final List<String> linkHrefs = getLinks(item).get(linkKey);
+        if (linkHrefs == null) {
+            return null;
+        }
         if (linkHrefs.size() > 1) {
             if (logger != null) {
                 logger.error("Hub Item has multiple links for key : " + linkKey + " : " + item.getJson());
             }
             throw new HubIntegrationException("Only expected to get a single link for the key : " + linkKey);
         }
+        if (linkHrefs.size() != 1) {
+            return null;
+        }
         return linkHrefs.get(0);
     }
 
+    // This public method will be replaced soon with a getLinks(item, linkName) method
+    @Deprecated
     public Map<String, List<String>> getLinks(final HubItem item) throws HubIntegrationException {
         final Map<String, List<String>> links = new HashMap<>();
         final JsonObject metaJson = getMeta(item);

--- a/src/main/java/com/blackducksoftware/integration/hub/api/notification/VulnerabilityNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/notification/VulnerabilityNotificationContent.java
@@ -28,7 +28,7 @@ import java.util.List;
 import org.apache.commons.lang3.builder.RecursiveToStringStyle;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
+import com.blackducksoftware.integration.hub.api.project.AffectedProjectVersion;
 import com.google.gson.annotations.SerializedName;
 
 public class VulnerabilityNotificationContent {
@@ -51,7 +51,7 @@ public class VulnerabilityNotificationContent {
 
     public String versionName;
 
-    public List<ProjectVersion> affectedProjectVersions;
+    public List<AffectedProjectVersion> affectedProjectVersions;
 
     public int getNewVulnerabilityCount() {
         return newVulnerabilityCount;
@@ -69,7 +69,7 @@ public class VulnerabilityNotificationContent {
         return versionName;
     }
 
-    public List<ProjectVersion> getAffectedProjectVersions() {
+    public List<AffectedProjectVersion> getAffectedProjectVersions() {
         return affectedProjectVersions;
     }
 
@@ -129,7 +129,7 @@ public class VulnerabilityNotificationContent {
         this.versionName = versionName;
     }
 
-    public void setAffectedProjectVersions(final List<ProjectVersion> affectedProjectVersions) {
+    public void setAffectedProjectVersions(final List<AffectedProjectVersion> affectedProjectVersions) {
         this.affectedProjectVersions = affectedProjectVersions;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/api/project/AffectedProjectVersion.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/project/AffectedProjectVersion.java
@@ -25,7 +25,13 @@ package com.blackducksoftware.integration.hub.api.project;
 
 import com.google.gson.annotations.SerializedName;
 
-public class ProjectVersion {
+/**
+ * An object of this class represents one item in an affectedProjectVersion list returned by the Hub.
+ * 
+ * @author sbillings
+ *
+ */
+public class AffectedProjectVersion {
 
     private String projectName;
 
@@ -58,4 +64,8 @@ public class ProjectVersion {
         this.url = url;
     }
 
+    @Override
+    public String toString() {
+        return "AffectedProjectVersion [projectName=" + projectName + ", projectVersionName=" + projectVersionName + ", url=" + url + "]";
+    }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/extension/ExtensionConfigDataService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/extension/ExtensionConfigDataService.java
@@ -24,7 +24,6 @@
 package com.blackducksoftware.integration.hub.dataservice.extension;
 
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +37,7 @@ import com.blackducksoftware.integration.hub.api.user.UserRequestService;
 import com.blackducksoftware.integration.hub.dataservice.extension.item.UserConfigItem;
 import com.blackducksoftware.integration.hub.dataservice.extension.transformer.UserConfigTransform;
 import com.blackducksoftware.integration.hub.dataservice.parallel.ParallelResourceProcessor;
+import com.blackducksoftware.integration.hub.dataservice.parallel.ParallelResourceProcessorResults;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.rest.RestConnection;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -57,10 +57,10 @@ public class ExtensionConfigDataService extends HubRequestService {
 
     private final MetaService metaService;
 
-    public ExtensionConfigDataService(IntLogger logger, final RestConnection restConnection, final UserRequestService userRequestService,
+    public ExtensionConfigDataService(final IntLogger logger, final RestConnection restConnection, final UserRequestService userRequestService,
             final HubRequestService hubRequestService,
             final ExtensionConfigRequestService extensionConfigRequestService,
-            final ExtensionUserOptionRequestService extensionUserOptionRequestService, MetaService metaService) {
+            final ExtensionUserOptionRequestService extensionUserOptionRequestService, final MetaService metaService) {
         super(restConnection);
         this.hubRequestService = hubRequestService;
         this.extensionConfigRequestService = extensionConfigRequestService;
@@ -80,14 +80,13 @@ public class ExtensionConfigDataService extends HubRequestService {
         return globalConfigMap;
     }
 
-    public List<UserConfigItem> getUserConfigList(final String extensionUrl) throws HubIntegrationException {
-        List<UserConfigItem> itemList = new LinkedList<>();
+    public ParallelResourceProcessorResults<UserConfigItem> getUserConfigList(final String extensionUrl) throws HubIntegrationException {
+
         final ExtensionItem extension = hubRequestService.getItem(extensionUrl, ExtensionItem.class);
         final String userOptionsLink = metaService.getLink(extension, MetaService.USER_OPTIONS_LINK);
         final List<UserOptionLinkItem> userOptionList = extensionUserOptionRequestService
                 .getUserOptions(userOptionsLink);
-        itemList = parallelProcessor.process(userOptionList);
-
+        final ParallelResourceProcessorResults<UserConfigItem> itemList = parallelProcessor.process(userOptionList);
         return itemList;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
@@ -46,6 +46,7 @@ import com.blackducksoftware.integration.hub.dataservice.notification.transforme
 import com.blackducksoftware.integration.hub.dataservice.notification.transformer.PolicyViolationTransformer;
 import com.blackducksoftware.integration.hub.dataservice.notification.transformer.VulnerabilityTransformer;
 import com.blackducksoftware.integration.hub.dataservice.parallel.ParallelResourceProcessor;
+import com.blackducksoftware.integration.hub.dataservice.parallel.ParallelResourceProcessorResults;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.rest.RestConnection;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -107,19 +108,23 @@ public class NotificationDataService extends HubRequestService {
                         versionBomPolicyRequestService, hubRequestService, policyNotificationFilter, metaService));
     }
 
-    public SortedSet<NotificationContentItem> getAllNotifications(final Date startDate, final Date endDate) throws HubIntegrationException {
+    public NotificationResults getAllNotifications(final Date startDate, final Date endDate) throws HubIntegrationException {
         final SortedSet<NotificationContentItem> contentList = new TreeSet<>();
         final List<NotificationItem> itemList = notificationRequestService.getAllNotifications(startDate, endDate);
-        contentList.addAll(parallelProcessor.process(itemList));
-        return contentList;
+        final ParallelResourceProcessorResults<NotificationContentItem> processorResults = parallelProcessor.process(itemList);
+        contentList.addAll(processorResults.getResults());
+        final NotificationResults results = new NotificationResults(contentList, processorResults.getErrorMessages());
+        return results;
     }
 
-    public SortedSet<NotificationContentItem> getUserNotifications(final Date startDate, final Date endDate, final UserItem user)
+    public NotificationResults getUserNotifications(final Date startDate, final Date endDate, final UserItem user)
             throws HubIntegrationException {
         final SortedSet<NotificationContentItem> contentList = new TreeSet<>();
         final List<NotificationItem> itemList = notificationRequestService.getUserNotifications(startDate, endDate, user);
-        contentList.addAll(parallelProcessor.process(itemList));
-        return contentList;
+        final ParallelResourceProcessorResults<NotificationContentItem> processorResults = parallelProcessor.process(itemList);
+        contentList.addAll(processorResults.getResults());
+        final NotificationResults results = new NotificationResults(contentList, processorResults.getErrorMessages());
+        return results;
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
@@ -68,18 +68,18 @@ public class NotificationDataService extends HubRequestService {
 
     private final MetaService metaService;
 
-    public NotificationDataService(IntLogger logger, RestConnection restConnection, NotificationRequestService notificationRequestService,
-            ProjectVersionRequestService projectVersionRequestService, PolicyRequestService policyRequestService,
-            VersionBomPolicyRequestService versionBomPolicyRequestService,
-            HubRequestService hubRequestService, MetaService metaService) {
+    public NotificationDataService(final IntLogger logger, final RestConnection restConnection, final NotificationRequestService notificationRequestService,
+            final ProjectVersionRequestService projectVersionRequestService, final PolicyRequestService policyRequestService,
+            final VersionBomPolicyRequestService versionBomPolicyRequestService,
+            final HubRequestService hubRequestService, final MetaService metaService) {
         this(logger, restConnection, notificationRequestService, projectVersionRequestService, policyRequestService, versionBomPolicyRequestService,
                 hubRequestService, null, metaService);
     }
 
-    public NotificationDataService(IntLogger logger, RestConnection restConnection, NotificationRequestService notificationRequestService,
-            ProjectVersionRequestService projectVersionRequestService, PolicyRequestService policyRequestService,
-            VersionBomPolicyRequestService versionBomPolicyRequestService,
-            HubRequestService hubRequestService, PolicyNotificationFilter policyNotificationFilter, MetaService metaService) {
+    public NotificationDataService(final IntLogger logger, final RestConnection restConnection, final NotificationRequestService notificationRequestService,
+            final ProjectVersionRequestService projectVersionRequestService, final PolicyRequestService policyRequestService,
+            final VersionBomPolicyRequestService versionBomPolicyRequestService,
+            final HubRequestService hubRequestService, final PolicyNotificationFilter policyNotificationFilter, final MetaService metaService) {
         super(restConnection);
         this.notificationRequestService = notificationRequestService;
         this.projectVersionRequestService = projectVersionRequestService;
@@ -101,7 +101,7 @@ public class NotificationDataService extends HubRequestService {
                         versionBomPolicyRequestService, hubRequestService, policyNotificationFilter, metaService));
         parallelProcessor.addTransform(VulnerabilityNotificationItem.class,
                 new VulnerabilityTransformer(notificationRequestService, projectVersionRequestService, policyRequestService,
-                        versionBomPolicyRequestService, hubRequestService));
+                        versionBomPolicyRequestService, hubRequestService, metaService));
         parallelProcessor.addTransform(RuleViolationClearedNotificationItem.class,
                 new PolicyViolationClearedTransformer(notificationRequestService, projectVersionRequestService, policyRequestService,
                         versionBomPolicyRequestService, hubRequestService, policyNotificationFilter, metaService));
@@ -114,7 +114,8 @@ public class NotificationDataService extends HubRequestService {
         return contentList;
     }
 
-    public SortedSet<NotificationContentItem> getUserNotifications(final Date startDate, final Date endDate, UserItem user) throws HubIntegrationException {
+    public SortedSet<NotificationContentItem> getUserNotifications(final Date startDate, final Date endDate, final UserItem user)
+            throws HubIntegrationException {
         final SortedSet<NotificationContentItem> contentList = new TreeSet<>();
         final List<NotificationItem> itemList = notificationRequestService.getUserNotifications(startDate, endDate, user);
         contentList.addAll(parallelProcessor.process(itemList));

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationDataService.java
@@ -113,7 +113,7 @@ public class NotificationDataService extends HubRequestService {
         final List<NotificationItem> itemList = notificationRequestService.getAllNotifications(startDate, endDate);
         final ParallelResourceProcessorResults<NotificationContentItem> processorResults = parallelProcessor.process(itemList);
         contentList.addAll(processorResults.getResults());
-        final NotificationResults results = new NotificationResults(contentList, processorResults.getErrorMessages());
+        final NotificationResults results = new NotificationResults(contentList, processorResults.getExceptions());
         return results;
     }
 
@@ -123,7 +123,7 @@ public class NotificationDataService extends HubRequestService {
         final List<NotificationItem> itemList = notificationRequestService.getUserNotifications(startDate, endDate, user);
         final ParallelResourceProcessorResults<NotificationContentItem> processorResults = parallelProcessor.process(itemList);
         contentList.addAll(processorResults.getResults());
-        final NotificationResults results = new NotificationResults(contentList, processorResults.getErrorMessages());
+        final NotificationResults results = new NotificationResults(contentList, processorResults.getExceptions());
         return results;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationResults.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationResults.java
@@ -31,24 +31,24 @@ import com.blackducksoftware.integration.hub.dataservice.notification.item.Notif
 public class NotificationResults {
     private final SortedSet<NotificationContentItem> notificationContentItems;
 
-    private final List<String> errorMessages;
+    private final List<Exception> exceptions;
 
-    public NotificationResults(final SortedSet<NotificationContentItem> notificationContentItems, final List<String> errorMessages) {
+    public NotificationResults(final SortedSet<NotificationContentItem> notificationContentItems, final List<Exception> exceptions) {
         super();
         this.notificationContentItems = notificationContentItems;
-        this.errorMessages = errorMessages;
+        this.exceptions = exceptions;
     }
 
     public SortedSet<NotificationContentItem> getNotificationContentItems() {
         return notificationContentItems;
     }
 
-    public List<String> getErrorMessages() {
-        return errorMessages;
+    public List<Exception> getExceptions() {
+        return exceptions;
     }
 
     public boolean isError() {
-        if ((errorMessages != null) && (errorMessages.size() > 0)) {
+        if ((exceptions != null) && (exceptions.size() > 0)) {
             return true;
         }
         return false;
@@ -56,7 +56,7 @@ public class NotificationResults {
 
     @Override
     public String toString() {
-        return "NotificationResults [notificationContentItems=" + notificationContentItems + ", errorMessages=" + errorMessages + "]";
+        return "NotificationResults [notificationContentItems=" + notificationContentItems + ", errorMessages=" + exceptions + "]";
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationResults.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/NotificationResults.java
@@ -1,0 +1,62 @@
+/**
+ * Hub Common
+ *
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.dataservice.notification;
+
+import java.util.List;
+import java.util.SortedSet;
+
+import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
+
+public class NotificationResults {
+    private final SortedSet<NotificationContentItem> notificationContentItems;
+
+    private final List<String> errorMessages;
+
+    public NotificationResults(final SortedSet<NotificationContentItem> notificationContentItems, final List<String> errorMessages) {
+        super();
+        this.notificationContentItems = notificationContentItems;
+        this.errorMessages = errorMessages;
+    }
+
+    public SortedSet<NotificationContentItem> getNotificationContentItems() {
+        return notificationContentItems;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public boolean isError() {
+        if ((errorMessages != null) && (errorMessages.size() > 0)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationResults [notificationContentItems=" + notificationContentItems + ", errorMessages=" + errorMessages + "]";
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/NotificationContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/NotificationContentItem.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import org.apache.commons.lang3.builder.RecursiveToStringStyle;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.google.common.base.Joiner;
 
 public class NotificationContentItem implements Comparable<NotificationContentItem> {

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyContentItem.java
@@ -25,8 +25,6 @@ package com.blackducksoftware.integration.hub.dataservice.notification.item;
 
 import java.util.Date;
 
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
-
 public class PolicyContentItem extends NotificationContentItem {
     private final String componentUrl;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyOverrideContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyOverrideContentItem.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 
 public class PolicyOverrideContentItem extends PolicyViolationContentItem {
     private final String firstName;

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyViolationClearedContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyViolationClearedContentItem.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 
 public class PolicyViolationClearedContentItem extends PolicyViolationContentItem {
     public PolicyViolationClearedContentItem(final Date createdAt, final ProjectVersion projectVersion,

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyViolationContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/PolicyViolationContentItem.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 
 public class PolicyViolationContentItem extends PolicyContentItem {
     private final List<PolicyRule> policyRuleList;

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/ProjectVersion.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/ProjectVersion.java
@@ -1,0 +1,220 @@
+/**
+ * Hub Common
+ *
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.dataservice.notification.item;
+
+import java.util.Date;
+
+import com.blackducksoftware.integration.hub.api.component.version.ComplexLicense;
+import com.blackducksoftware.integration.hub.api.component.version.SourceEnum;
+import com.blackducksoftware.integration.hub.api.version.DistributionEnum;
+import com.blackducksoftware.integration.hub.api.version.PhaseEnum;
+
+public class ProjectVersion {
+    private String projectName;
+
+    private String projectVersionName;
+
+    private String url;
+
+    private DistributionEnum distribution;
+
+    private ComplexLicense license;
+
+    private String nickname;
+
+    private PhaseEnum phase;
+
+    private String releaseComments;
+
+    private Date releasedOn;
+
+    // description from Hub API: "Read-Only; No matter the value it will always default to 'CUSTOM'",
+    private SourceEnum source;
+
+    private String versionName;
+
+    private String versionReportLink;
+
+    private String riskProfileLink;
+
+    private String componentsLink;
+
+    private String vulnerableComponentsLink;
+
+    private String projectLink;
+
+    private String policyStatusLink;
+
+    private String codeLocationsLink;
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(final String projectName) {
+        this.projectName = projectName;
+    }
+
+    public String getProjectVersionName() {
+        return projectVersionName;
+    }
+
+    public void setProjectVersionName(final String projectVersionName) {
+        this.projectVersionName = projectVersionName;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public DistributionEnum getDistribution() {
+        return distribution;
+    }
+
+    public void setDistribution(final DistributionEnum distribution) {
+        this.distribution = distribution;
+    }
+
+    public ComplexLicense getLicense() {
+        return license;
+    }
+
+    public void setLicense(final ComplexLicense license) {
+        this.license = license;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public PhaseEnum getPhase() {
+        return phase;
+    }
+
+    public void setPhase(final PhaseEnum phase) {
+        this.phase = phase;
+    }
+
+    public String getReleaseComments() {
+        return releaseComments;
+    }
+
+    public void setReleaseComments(final String releaseComments) {
+        this.releaseComments = releaseComments;
+    }
+
+    public Date getReleasedOn() {
+        return releasedOn;
+    }
+
+    public void setReleasedOn(final Date releasedOn) {
+        this.releasedOn = releasedOn;
+    }
+
+    public SourceEnum getSource() {
+        return source;
+    }
+
+    public void setSource(final SourceEnum source) {
+        this.source = source;
+    }
+
+    public String getVersionName() {
+        return versionName;
+    }
+
+    public void setVersionName(final String versionName) {
+        this.versionName = versionName;
+    }
+
+    public String getVersionReportLink() {
+        return versionReportLink;
+    }
+
+    public void setVersionReportLink(final String versionReportLink) {
+        this.versionReportLink = versionReportLink;
+    }
+
+    public String getRiskProfileLink() {
+        return riskProfileLink;
+    }
+
+    public void setRiskProfileLink(final String riskProfileLink) {
+        this.riskProfileLink = riskProfileLink;
+    }
+
+    public String getComponentsLink() {
+        return componentsLink;
+    }
+
+    public void setComponentsLink(final String componentsLink) {
+        this.componentsLink = componentsLink;
+    }
+
+    public String getVulnerableComponentsLink() {
+        return vulnerableComponentsLink;
+    }
+
+    public void setVulnerableComponentsLink(final String vulnerableComponentsLink) {
+        this.vulnerableComponentsLink = vulnerableComponentsLink;
+    }
+
+    public String getProjectLink() {
+        return projectLink;
+    }
+
+    public void setProjectLink(final String projectLink) {
+        this.projectLink = projectLink;
+    }
+
+    public String getPolicyStatusLink() {
+        return policyStatusLink;
+    }
+
+    public void setPolicyStatusLink(final String policyStatusLink) {
+        this.policyStatusLink = policyStatusLink;
+    }
+
+    public String getCodeLocationsLink() {
+        return codeLocationsLink;
+    }
+
+    public void setCodeLocationsLink(final String codeLocationsLink) {
+        this.codeLocationsLink = codeLocationsLink;
+    }
+
+    @Override
+    public String toString() {
+        return "ProjectVersion [projectName=" + projectName + ", projectVersionName=" + projectVersionName + "]";
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/VulnerabilityContentItem.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/item/VulnerabilityContentItem.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.notification.VulnerabilitySourceQualifiedId;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 
 public class VulnerabilityContentItem extends NotificationContentItem {
     private final List<VulnerabilitySourceQualifiedId> addedVulnList;

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/AbstractPolicyTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/AbstractPolicyTransformer.java
@@ -37,12 +37,12 @@ import com.blackducksoftware.integration.hub.api.notification.NotificationItem;
 import com.blackducksoftware.integration.hub.api.notification.NotificationRequestService;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRequestService;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
 import com.blackducksoftware.integration.hub.api.version.BomComponentVersionPolicyStatus;
 import com.blackducksoftware.integration.hub.api.version.VersionBomPolicyRequestService;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyNotificationFilter;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -58,8 +58,9 @@ public abstract class AbstractPolicyTransformer extends AbstractNotificationTran
      */
     public AbstractPolicyTransformer(final NotificationRequestService notificationService,
             final ProjectVersionRequestService projectVersionService, final PolicyRequestService policyService,
-            final VersionBomPolicyRequestService bomVersionPolicyService, HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter,
-            MetaService metaService) {
+            final VersionBomPolicyRequestService bomVersionPolicyService, final HubRequestService hubRequestService,
+            final PolicyNotificationFilter policyFilter,
+            final MetaService metaService) {
         super(notificationService, projectVersionService, policyService, bomVersionPolicyService, hubRequestService);
         this.policyFilter = policyFilter;
         this.metaService = metaService;
@@ -132,7 +133,7 @@ public abstract class AbstractPolicyTransformer extends AbstractNotificationTran
         final List<PolicyRule> filteredRules = new ArrayList<>();
         if (policyFilter != null && policyFilter.getRuleLinksToInclude() != null) {
             for (final PolicyRule ruleViolated : rulesViolated) {
-                String ruleHref = metaService.getHref(ruleViolated);
+                final String ruleHref = metaService.getHref(ruleViolated);
                 if (policyFilter.getRuleLinksToInclude().contains(ruleHref)) {
                     filteredRules.add(ruleViolated);
                 }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationClearedTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationClearedTransformer.java
@@ -34,13 +34,13 @@ import com.blackducksoftware.integration.hub.api.notification.NotificationReques
 import com.blackducksoftware.integration.hub.api.notification.RuleViolationClearedNotificationItem;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRequestService;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionItem;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
 import com.blackducksoftware.integration.hub.api.version.VersionBomPolicyRequestService;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyNotificationFilter;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyViolationClearedContentItem;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -49,7 +49,7 @@ public class PolicyViolationClearedTransformer extends AbstractPolicyTransformer
     public PolicyViolationClearedTransformer(final NotificationRequestService notificationService,
             final ProjectVersionRequestService projectVersionService, final PolicyRequestService policyService,
             final VersionBomPolicyRequestService bomVersionPolicyService,
-            HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, MetaService metaService) {
+            final HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, final MetaService metaService) {
         super(notificationService, projectVersionService, policyService, bomVersionPolicyService,
                 hubRequestService, policyFilter, metaService);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationOverrideTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationOverrideTransformer.java
@@ -37,7 +37,6 @@ import com.blackducksoftware.integration.hub.api.notification.NotificationReques
 import com.blackducksoftware.integration.hub.api.notification.PolicyOverrideNotificationItem;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRequestService;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionItem;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
 import com.blackducksoftware.integration.hub.api.version.BomComponentVersionPolicyStatus;
@@ -45,6 +44,7 @@ import com.blackducksoftware.integration.hub.api.version.VersionBomPolicyRequest
 import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyNotificationFilter;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyOverrideContentItem;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -53,7 +53,7 @@ public class PolicyViolationOverrideTransformer extends AbstractPolicyTransforme
     public PolicyViolationOverrideTransformer(final NotificationRequestService notificationService,
             final ProjectVersionRequestService projectVersionService, final PolicyRequestService policyService,
             final VersionBomPolicyRequestService bomVersionPolicyService,
-            HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, MetaService metaService) {
+            final HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, final MetaService metaService) {
         super(notificationService, projectVersionService, policyService, bomVersionPolicyService,
                 hubRequestService, policyFilter, metaService);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/PolicyViolationTransformer.java
@@ -34,13 +34,13 @@ import com.blackducksoftware.integration.hub.api.notification.NotificationReques
 import com.blackducksoftware.integration.hub.api.notification.RuleViolationNotificationItem;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRequestService;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionItem;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
 import com.blackducksoftware.integration.hub.api.version.VersionBomPolicyRequestService;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyNotificationFilter;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyViolationContentItem;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
@@ -49,7 +49,7 @@ public class PolicyViolationTransformer extends AbstractPolicyTransformer {
     public PolicyViolationTransformer(final NotificationRequestService notificationService,
             final ProjectVersionRequestService projectVersionService, final PolicyRequestService policyService,
             final VersionBomPolicyRequestService bomVersionPolicyService,
-            final HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, MetaService metaService) {
+            final HubRequestService hubRequestService, final PolicyNotificationFilter policyFilter, final MetaService metaService) {
         super(notificationService, projectVersionService, policyService, bomVersionPolicyService,
                 hubRequestService, policyFilter, metaService);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/VulnerabilityTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/VulnerabilityTransformer.java
@@ -125,7 +125,7 @@ public class VulnerabilityTransformer extends AbstractNotificationTransformer {
         fullProjectVersion.setReleasedOn(item.getReleasedOn());
         fullProjectVersion.setSource(item.getSource());
 
-        fullProjectVersion.setUrl(metaService.getHref(item));
+        fullProjectVersion.setUrl(metaService.getHref(item)); // TODO catch npe's here?
         fullProjectVersion.setCodeLocationsLink((metaService.getLink(item, MetaService.CODE_LOCATION_LINK)));
         fullProjectVersion.setComponentsLink((metaService.getLink(item, MetaService.COMPONENTS_LINK)));
         fullProjectVersion.setPolicyStatusLink((metaService.getLink(item, MetaService.POLICY_STATUS_LINK)));

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/VulnerabilityTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/notification/transformer/VulnerabilityTransformer.java
@@ -26,27 +26,34 @@ package com.blackducksoftware.integration.hub.dataservice.notification.transform
 import java.util.ArrayList;
 import java.util.List;
 
+import com.blackducksoftware.integration.hub.api.item.MetaService;
 import com.blackducksoftware.integration.hub.api.notification.NotificationItem;
 import com.blackducksoftware.integration.hub.api.notification.NotificationRequestService;
 import com.blackducksoftware.integration.hub.api.notification.VulnerabilityNotificationContent;
 import com.blackducksoftware.integration.hub.api.notification.VulnerabilityNotificationItem;
 import com.blackducksoftware.integration.hub.api.notification.VulnerabilitySourceQualifiedId;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRequestService;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
+import com.blackducksoftware.integration.hub.api.project.AffectedProjectVersion;
+import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionItem;
 import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService;
 import com.blackducksoftware.integration.hub.api.version.VersionBomPolicyRequestService;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.NotificationContentItem;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.VulnerabilityContentItem;
+import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubRequestService;
 
 public class VulnerabilityTransformer extends AbstractNotificationTransformer {
+    private final MetaService metaService;
+
     public VulnerabilityTransformer(final NotificationRequestService notificationService,
             final ProjectVersionRequestService projectVersionService, final PolicyRequestService policyService,
             final VersionBomPolicyRequestService bomVersionPolicyService,
-            final HubRequestService hubRequestService) {
+            final HubRequestService hubRequestService, final MetaService metaService) {
         super(notificationService, projectVersionService, policyService, bomVersionPolicyService,
                 hubRequestService);
+        this.metaService = metaService;
     }
 
     @Override
@@ -71,9 +78,9 @@ public class VulnerabilityTransformer extends AbstractNotificationTransformer {
                     vulnerabilityNotificationContent.getDeletedVulnerabilityCount(),
                     vulnerabilityNotificationContent.getDeletedVulnerabilityIds());
 
-            final List<ProjectVersion> projectVersionList = vulnerabilityNotificationItem.getContent()
+            final List<AffectedProjectVersion> affectedProjectVersionList = vulnerabilityNotificationItem.getContent()
                     .getAffectedProjectVersions();
-            if (projectVersionList == null || projectVersionList.isEmpty()) {
+            if (affectedProjectVersionList == null || affectedProjectVersionList.isEmpty()) {
                 notificationContentItems
                         .add(new VulnerabilityContentItem(item.getCreatedAt(), new ProjectVersion(),
                                 componentName, componentVersionName,
@@ -81,9 +88,10 @@ public class VulnerabilityTransformer extends AbstractNotificationTransformer {
                                 updatedVulnList,
                                 deletedVulnList));
             } else {
-                for (final ProjectVersion projectVersion : projectVersionList) {
+                for (final AffectedProjectVersion affectedProjectVersion : affectedProjectVersionList) {
+                    final ProjectVersion fullProjectVersion = createFullProjectVersion(affectedProjectVersion);
                     notificationContentItems
-                            .add(new VulnerabilityContentItem(item.getCreatedAt(), projectVersion,
+                            .add(new VulnerabilityContentItem(item.getCreatedAt(), fullProjectVersion,
                                     componentName, componentVersionName,
                                     componentVersionUrl, addedVulnList,
                                     updatedVulnList,
@@ -94,6 +102,39 @@ public class VulnerabilityTransformer extends AbstractNotificationTransformer {
             throw new HubItemTransformException(e);
         }
         return notificationContentItems;
+    }
+
+    private ProjectVersion createFullProjectVersion(final AffectedProjectVersion affectedProjectVersion) throws HubIntegrationException {
+        final String url = affectedProjectVersion.getUrl();
+        ProjectVersionItem item;
+        try {
+            item = getHubRequestService().getItem(url, ProjectVersionItem.class);
+        } catch (final HubIntegrationException e) {
+            final String msg = "Error getting the full ProjectVersion for this affected project version: "
+                    + affectedProjectVersion + ": " + e.getMessage();
+            throw new HubIntegrationException(msg, e);
+        }
+        final ProjectVersion fullProjectVersion = new ProjectVersion();
+        fullProjectVersion.setProjectName(affectedProjectVersion.getProjectName());
+        fullProjectVersion.setProjectVersionName(affectedProjectVersion.getProjectVersionName());
+        fullProjectVersion.setDistribution(item.getDistribution());
+        fullProjectVersion.setLicense(item.getLicense());
+        fullProjectVersion.setNickname(item.getNickname());
+        fullProjectVersion.setPhase(item.getPhase());
+        fullProjectVersion.setReleaseComments(item.getReleaseComments());
+        fullProjectVersion.setReleasedOn(item.getReleasedOn());
+        fullProjectVersion.setSource(item.getSource());
+
+        fullProjectVersion.setUrl(metaService.getHref(item));
+        fullProjectVersion.setCodeLocationsLink((metaService.getLink(item, MetaService.CODE_LOCATION_LINK)));
+        fullProjectVersion.setComponentsLink((metaService.getLink(item, MetaService.COMPONENTS_LINK)));
+        fullProjectVersion.setPolicyStatusLink((metaService.getLink(item, MetaService.POLICY_STATUS_LINK)));
+        fullProjectVersion.setProjectLink((metaService.getLink(item, MetaService.PROJECT_LINK)));
+        fullProjectVersion.setRiskProfileLink((metaService.getLink(item, MetaService.RISK_PROFILE_LINK)));
+        fullProjectVersion.setVersionReportLink((metaService.getLink(item, MetaService.VERSION_REPORT_LINK)));
+        fullProjectVersion.setVulnerableComponentsLink((metaService.getLink(item, MetaService.VULNERABLE_COMPONENTS_LINK)));
+
+        return fullProjectVersion;
     }
 
     private List<VulnerabilitySourceQualifiedId> extractIdList(final int count,

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessor.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessor.java
@@ -93,7 +93,7 @@ public class ParallelResourceProcessor<R, S> {
 
     private ParallelResourceProcessorResults<R> processItems(final int submitted) {
         final List<R> resultsList = new LinkedList<>();
-        final List<String> errorMessages = new ArrayList<>();
+        final List<Exception> exceptions = new ArrayList<>();
         for (int index = 0; index < submitted; index++) {
             try {
                 final Future<List<R>> future = completionService.take();
@@ -102,10 +102,10 @@ public class ParallelResourceProcessor<R, S> {
             } catch (final ExecutionException | InterruptedException e) {
                 final String msg = "Error from parallel task: " + e.getMessage();
                 logger.error(msg, e);
-                errorMessages.add(msg);
+                exceptions.add(e);
             }
         }
-        final ParallelResourceProcessorResults<R> resultsObject = new ParallelResourceProcessorResults<>(resultsList, errorMessages);
+        final ParallelResourceProcessorResults<R> resultsObject = new ParallelResourceProcessorResults<>(resultsList, exceptions);
         return resultsObject;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessorResults.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessorResults.java
@@ -29,27 +29,27 @@ import java.util.List;
 public class ParallelResourceProcessorResults<R> {
     private final List<R> results;
 
-    private final List<String> errorMessages;
+    private final List<Exception> exceptions;
 
-    public ParallelResourceProcessorResults(final List<R> results, final List<String> exceptionMessages) {
+    public ParallelResourceProcessorResults(final List<R> results, final List<Exception> exceptionMessages) {
         if (results == null) {
             this.results = new ArrayList<>();
         } else {
             this.results = results;
         }
-        this.errorMessages = exceptionMessages;
+        this.exceptions = exceptionMessages;
     }
 
     public List<R> getResults() {
         return results;
     }
 
-    public List<String> getErrorMessages() {
-        return errorMessages;
+    public List<Exception> getExceptions() {
+        return exceptions;
     }
 
     public boolean isError() {
-        if ((errorMessages != null) && (errorMessages.size() > 0)) {
+        if ((exceptions != null) && (exceptions.size() > 0)) {
             return true;
         }
         return false;
@@ -57,6 +57,6 @@ public class ParallelResourceProcessorResults<R> {
 
     @Override
     public String toString() {
-        return "ParallelResourceProcessorResults [results=" + results + ", errorMessages=" + errorMessages + "]";
+        return "ParallelResourceProcessorResults [results=" + results + ", errorMessages=" + exceptions + "]";
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessorResults.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/dataservice/parallel/ParallelResourceProcessorResults.java
@@ -1,0 +1,62 @@
+/**
+ * Hub Common
+ *
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.dataservice.parallel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ParallelResourceProcessorResults<R> {
+    private final List<R> results;
+
+    private final List<String> errorMessages;
+
+    public ParallelResourceProcessorResults(final List<R> results, final List<String> exceptionMessages) {
+        if (results == null) {
+            this.results = new ArrayList<>();
+        } else {
+            this.results = results;
+        }
+        this.errorMessages = exceptionMessages;
+    }
+
+    public List<R> getResults() {
+        return results;
+    }
+
+    public List<String> getErrorMessages() {
+        return errorMessages;
+    }
+
+    public boolean isError() {
+        if ((errorMessages != null) && (errorMessages.size() > 0)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "ParallelResourceProcessorResults [results=" + results + ", errorMessages=" + errorMessages + "]";
+    }
+}

--- a/src/test/java/com/blackducksoftware/integration/hub/notification/processor/EventTestUtil.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/notification/processor/EventTestUtil.java
@@ -33,12 +33,12 @@ import org.mockito.Mockito;
 
 import com.blackducksoftware.integration.hub.api.notification.VulnerabilitySourceQualifiedId;
 import com.blackducksoftware.integration.hub.api.policy.PolicyRule;
-import com.blackducksoftware.integration.hub.api.project.ProjectVersion;
 import com.blackducksoftware.integration.hub.api.vulnerability.SeverityEnum;
 import com.blackducksoftware.integration.hub.api.vulnerability.VulnerabilityItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyOverrideContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyViolationClearedContentItem;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.PolicyViolationContentItem;
+import com.blackducksoftware.integration.hub.dataservice.notification.item.ProjectVersion;
 import com.blackducksoftware.integration.hub.dataservice.notification.item.VulnerabilityContentItem;
 import com.blackducksoftware.integration.hub.meta.MetaAllowEnum;
 
@@ -119,7 +119,7 @@ public class EventTestUtil {
 
     public static final List<MetaAllowEnum> ALLOW_LIST = Collections.emptyList();
 
-    public List<VulnerabilityItem> createVulnerabiltyItemList(List<VulnerabilitySourceQualifiedId> vulnSourceList) {
+    public List<VulnerabilityItem> createVulnerabiltyItemList(final List<VulnerabilitySourceQualifiedId> vulnSourceList) {
         final List<VulnerabilityItem> vulnerabilityList = new ArrayList<>(vulnSourceList.size());
         for (final VulnerabilitySourceQualifiedId vulnSource : vulnSourceList) {
             final String vulnId = vulnSource.getVulnerabilityId();
@@ -157,7 +157,7 @@ public class EventTestUtil {
         return item;
     }
 
-    public PolicyRule createPolicyRule(String name, String description, String createdBy, String updatedBy, String href) {
+    public PolicyRule createPolicyRule(final String name, final String description, final String createdBy, final String updatedBy, final String href) {
         final PolicyRule rule = Mockito.mock(PolicyRule.class);
         Mockito.when(rule.getName()).thenReturn(name);
         Mockito.when(rule.getDescription()).thenReturn(description);
@@ -172,7 +172,7 @@ public class EventTestUtil {
         return rule;
     }
 
-    public String createPolicyRuleJSon(String href) {
+    public String createPolicyRuleJSon(final String href) {
         return "{ \"_meta\": { \"href\": \"" + href + "\" }}";
     }
 


### PR DESCRIPTION
Separated out ProjectVersion (dataservice layer) from AffectedProjectVersion (api layer).
Fixed NPE in MetaService
ParallelResourceProcessor.process() now returns an object that includes a list of exceptions caught. Similar change to notification service get*Notifications().