### PR TITLE
Changes to handle notification processing of the content field.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 plugins { id 'groovy' }
 
-version = '27.0.1-SNAPSHOT'
+version = '28.0.0-SNAPSHOT'
 
 apply plugin: 'com.blackducksoftware.integration.library'
 

--- a/src/main/java/com/blackducksoftware/integration/hub/api/view/PolicyOverrideNotificationView.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/view/PolicyOverrideNotificationView.java
@@ -23,10 +23,9 @@
  */
 package com.blackducksoftware.integration.hub.api.view;
 
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.response.PolicyOverrideNotificationContent;
 
-public class PolicyOverrideNotificationView extends NotificationView {
+public class PolicyOverrideNotificationView extends ReducedNotificationView {
     public PolicyOverrideNotificationContent content;
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/api/view/ReducedNotificationView.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/view/ReducedNotificationView.java
@@ -23,9 +23,19 @@
  */
 package com.blackducksoftware.integration.hub.api.view;
 
-import com.blackducksoftware.integration.hub.api.response.RuleViolationNotificationContent;
+import com.blackducksoftware.integration.hub.api.core.HubView;
+import com.blackducksoftware.integration.hub.api.generated.enumeration.NotificationType;
 
-public class RuleViolationNotificationView extends ReducedNotificationView {
-    public RuleViolationNotificationContent content;
+// This is named a ReducedNotificationView because it removes the 'content' member from NotificationView which is generated.
+// This is a short term fix to release dependent projects.  A larger more appropriate fix to extract content will be made in a future release.
+// In a future release this object will be removed and the parallel processing will extract the content from the notifications.
+public abstract class ReducedNotificationView extends HubView {
+    public String contentType;
+    public java.util.Date createdAt;
+    public NotificationType type;
 
+    public ReducedNotificationView() {
+        // gson requires a default constructor.
+        // this class is abstract because it must be sub-classed to define the content member.
+    }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/api/view/RuleViolationClearedNotificationView.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/view/RuleViolationClearedNotificationView.java
@@ -23,10 +23,9 @@
  */
 package com.blackducksoftware.integration.hub.api.view;
 
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.response.RuleViolationClearedNotificationContent;
 
-public class RuleViolationClearedNotificationView extends NotificationView {
+public class RuleViolationClearedNotificationView extends ReducedNotificationView {
     public RuleViolationClearedNotificationContent content;
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/api/view/VulnerabilityNotificationView.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/api/view/VulnerabilityNotificationView.java
@@ -23,10 +23,9 @@
  */
 package com.blackducksoftware.integration.hub.api.view;
 
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.response.VulnerabilityNotificationContent;
 
-public class VulnerabilityNotificationView extends NotificationView {
+public class VulnerabilityNotificationView extends ReducedNotificationView {
     public VulnerabilityNotificationContent content;
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/AbstractNotificationTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/AbstractNotificationTransformer.java
@@ -29,15 +29,15 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.generated.view.ProjectVersionView;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubService;
 import com.blackducksoftware.integration.log.IntLogger;
 import com.blackducksoftware.integration.parallel.processor.ItemTransformer;
 
-public abstract class AbstractNotificationTransformer implements ItemTransformer<NotificationContentItem, NotificationView> {
+public abstract class AbstractNotificationTransformer implements ItemTransformer<NotificationContentItem, ReducedNotificationView> {
     final IntLogger logger;
     final HubService hubService;
 
@@ -47,7 +47,7 @@ public abstract class AbstractNotificationTransformer implements ItemTransformer
     }
 
     @Override
-    public abstract List<NotificationContentItem> transform(NotificationView item) throws HubItemTransformException;
+    public abstract List<NotificationContentItem> transform(ReducedNotificationView item) throws HubItemTransformException;
 
     protected ProjectVersionModel createFullProjectVersion(final String projectVersionUrl, final String projectName, final String versionName) throws IntegrationException {
         ProjectVersionView item;

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/AbstractPolicyTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/AbstractPolicyTransformer.java
@@ -29,11 +29,11 @@ import java.util.List;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyRuleView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyStatusView;
 import com.blackducksoftware.integration.hub.api.generated.view.ProjectVersionView;
 import com.blackducksoftware.integration.hub.api.response.ComponentVersionStatus;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubService;
 
@@ -49,7 +49,7 @@ public abstract class AbstractPolicyTransformer extends AbstractNotificationTran
     }
 
     public abstract void handleNotification(final List<ComponentVersionStatus> componentVersionList,
-            final String projectName, final ProjectVersionView releaseItem, final NotificationView item,
+            final String projectName, final ProjectVersionView releaseItem, final ReducedNotificationView item,
             final List<NotificationContentItem> templateData) throws HubItemTransformException;
 
     protected List<PolicyRuleView> getRulesFromUrls(final List<String> ruleUrlsViolated) throws IntegrationException {
@@ -142,5 +142,5 @@ public abstract class AbstractPolicyTransformer extends AbstractNotificationTran
     public abstract void createContents(final ProjectVersionModel projectVersion, final String componentName,
             final ComponentVersionView componentVersion, final String componentUrl, final String componentVersionUrl,
             List<PolicyRuleView> policyRuleList,
-            NotificationView item, List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException;
+            ReducedNotificationView item, List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException;
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationClearedTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationClearedTransformer.java
@@ -29,10 +29,10 @@ import java.util.List;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyRuleView;
 import com.blackducksoftware.integration.hub.api.generated.view.ProjectVersionView;
 import com.blackducksoftware.integration.hub.api.response.ComponentVersionStatus;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.api.view.RuleViolationClearedNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubService;
@@ -43,7 +43,7 @@ public class PolicyViolationClearedTransformer extends AbstractPolicyTransformer
     }
 
     @Override
-    public List<NotificationContentItem> transform(final NotificationView item) throws HubItemTransformException {
+    public List<NotificationContentItem> transform(final ReducedNotificationView item) throws HubItemTransformException {
         final List<NotificationContentItem> templateData = new ArrayList<>();
 
         final RuleViolationClearedNotificationView policyViolation = (RuleViolationClearedNotificationView) item;
@@ -70,7 +70,7 @@ public class PolicyViolationClearedTransformer extends AbstractPolicyTransformer
 
     @Override
     public void handleNotification(final List<ComponentVersionStatus> componentVersionList,
-            final String projectName, final ProjectVersionView releaseItem, final NotificationView item,
+            final String projectName, final ProjectVersionView releaseItem, final ReducedNotificationView item,
             final List<NotificationContentItem> templateData) throws HubItemTransformException {
         for (final ComponentVersionStatus componentVersion : componentVersionList) {
             try {
@@ -111,7 +111,7 @@ public class PolicyViolationClearedTransformer extends AbstractPolicyTransformer
     @Override
     public void createContents(final ProjectVersionModel projectVersion, final String componentName,
             final ComponentVersionView componentVersion, final String componentUrl, final String componentVersionUrl,
-            final List<PolicyRuleView> policyRuleList, final NotificationView item,
+            final List<PolicyRuleView> policyRuleList, final ReducedNotificationView item,
             final List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException {
         final PolicyViolationClearedContentItem contentItem = new PolicyViolationClearedContentItem(item.createdAt,
                 projectVersion, componentName, componentVersion, componentUrl,

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationOverrideTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationOverrideTransformer.java
@@ -32,12 +32,12 @@ import org.apache.commons.lang3.StringUtils;
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.enumeration.PolicyStatusApprovalStatusType;
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyRuleView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyStatusView;
 import com.blackducksoftware.integration.hub.api.generated.view.ProjectVersionView;
 import com.blackducksoftware.integration.hub.api.response.ComponentVersionStatus;
 import com.blackducksoftware.integration.hub.api.view.PolicyOverrideNotificationView;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubService;
 
@@ -47,7 +47,7 @@ public class PolicyViolationOverrideTransformer extends AbstractPolicyTransforme
     }
 
     @Override
-    public List<NotificationContentItem> transform(final NotificationView item) throws HubItemTransformException {
+    public List<NotificationContentItem> transform(final ReducedNotificationView item) throws HubItemTransformException {
         final List<NotificationContentItem> templateData = new ArrayList<>();
         final ProjectVersionView releaseItem;
         final PolicyOverrideNotificationView policyOverride = (PolicyOverrideNotificationView) item;
@@ -72,7 +72,7 @@ public class PolicyViolationOverrideTransformer extends AbstractPolicyTransforme
 
     @Override
     public void handleNotification(final List<ComponentVersionStatus> componentVersionList,
-            final String projectName, final ProjectVersionView releaseItem, final NotificationView item,
+            final String projectName, final ProjectVersionView releaseItem, final ReducedNotificationView item,
             final List<NotificationContentItem> templateData) throws HubItemTransformException {
 
         final PolicyOverrideNotificationView policyOverrideItem = (PolicyOverrideNotificationView) item;
@@ -122,7 +122,7 @@ public class PolicyViolationOverrideTransformer extends AbstractPolicyTransforme
     @Override
     public void createContents(final ProjectVersionModel projectVersion, final String componentName,
             final ComponentVersionView componentVersion, final String componentUrl, final String componentVersionUrl,
-            final List<PolicyRuleView> policyRuleList, final NotificationView item,
+            final List<PolicyRuleView> policyRuleList, final ReducedNotificationView item,
             final List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException {
         final PolicyOverrideNotificationView policyOverride = (PolicyOverrideNotificationView) item;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/PolicyViolationTransformer.java
@@ -29,10 +29,10 @@ import java.util.List;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.generated.view.PolicyRuleView;
 import com.blackducksoftware.integration.hub.api.generated.view.ProjectVersionView;
 import com.blackducksoftware.integration.hub.api.response.ComponentVersionStatus;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.api.view.RuleViolationNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
 import com.blackducksoftware.integration.hub.service.HubService;
@@ -43,7 +43,7 @@ public class PolicyViolationTransformer extends AbstractPolicyTransformer {
     }
 
     @Override
-    public List<NotificationContentItem> transform(final NotificationView item) throws HubItemTransformException {
+    public List<NotificationContentItem> transform(final ReducedNotificationView item) throws HubItemTransformException {
         final List<NotificationContentItem> templateData = new ArrayList<>();
         final RuleViolationNotificationView policyViolation = (RuleViolationNotificationView) item;
         final String projectName = policyViolation.content.projectName;
@@ -62,7 +62,8 @@ public class PolicyViolationTransformer extends AbstractPolicyTransformer {
     }
 
     @Override
-    public void handleNotification(final List<ComponentVersionStatus> componentVersionList, final String projectName, final ProjectVersionView releaseItem, final NotificationView item, final List<NotificationContentItem> templateData)
+    public void handleNotification(final List<ComponentVersionStatus> componentVersionList, final String projectName, final ProjectVersionView releaseItem, final ReducedNotificationView item,
+            final List<NotificationContentItem> templateData)
             throws HubItemTransformException {
         for (final ComponentVersionStatus componentVersion : componentVersionList) {
             try {
@@ -103,7 +104,7 @@ public class PolicyViolationTransformer extends AbstractPolicyTransformer {
 
     @Override
     public void createContents(final ProjectVersionModel projectVersion, final String componentName, final ComponentVersionView componentVersion, final String componentUrl, final String componentVersionUrl,
-            final List<PolicyRuleView> policyRuleList, final NotificationView item, final List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException {
+            final List<PolicyRuleView> policyRuleList, final ReducedNotificationView item, final List<NotificationContentItem> templateData, final String componentIssueUrl) throws URISyntaxException {
         templateData.add(new PolicyViolationContentItem(item.createdAt, projectVersion, componentName, componentVersion, componentUrl, componentVersionUrl, policyRuleList, componentIssueUrl));
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/VulnerabilityTransformer.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/VulnerabilityTransformer.java
@@ -27,10 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.generated.view.ComponentVersionView;
-import com.blackducksoftware.integration.hub.api.generated.view.NotificationView;
 import com.blackducksoftware.integration.hub.api.response.AffectedProjectVersion;
 import com.blackducksoftware.integration.hub.api.response.VulnerabilityNotificationContent;
 import com.blackducksoftware.integration.hub.api.response.VulnerabilitySourceQualifiedId;
+import com.blackducksoftware.integration.hub.api.view.ReducedNotificationView;
 import com.blackducksoftware.integration.hub.api.view.VulnerabilityNotificationView;
 import com.blackducksoftware.integration.hub.exception.HubIntegrationException;
 import com.blackducksoftware.integration.hub.exception.HubItemTransformException;
@@ -42,7 +42,7 @@ public class VulnerabilityTransformer extends AbstractNotificationTransformer {
     }
 
     @Override
-    public List<NotificationContentItem> transform(final NotificationView item) throws HubItemTransformException {
+    public List<NotificationContentItem> transform(final ReducedNotificationView item) throws HubItemTransformException {
         final List<NotificationContentItem> notificationContentItems = new ArrayList<>();
         try {
             final VulnerabilityNotificationView vulnerabilityNotificationItem = (VulnerabilityNotificationView) item;

--- a/src/main/java/com/blackducksoftware/integration/hub/service/ComponentService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/ComponentService.java
@@ -42,8 +42,8 @@ public class ComponentService extends DataService {
         super(hubService);
     }
 
-    public ComponentVersionView getExactComponentVersionFromComponent(final ExternalId externalId) throws IntegrationException {
-        for (final ComponentVersionView componentVersion : this.getAllComponentVersionsFromComponent(externalId)) {
+    public ComponentVersionView getComponentVersion(final ExternalId externalId) throws IntegrationException {
+        for (final ComponentVersionView componentVersion : this.getAllComponentVersions(externalId)) {
             if (componentVersion.versionName.equals(externalId.version)) {
                 return componentVersion;
             }
@@ -53,7 +53,7 @@ public class ComponentService extends DataService {
         throw new HubIntegrationException(errMsg);
     }
 
-    public List<ComponentVersionView> getAllComponentVersionsFromComponent(final ExternalId externalId) throws IntegrationException {
+    public List<ComponentVersionView> getAllComponentVersions(final ExternalId externalId) throws IntegrationException {
         final ComponentSearchResultView componentSearchView = getExactComponentMatch(externalId);
         final ComponentView componentView = hubService.getResponse(componentSearchView.component, ComponentView.class);
 

--- a/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/BdioUploadRecipeTest.java
+++ b/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/BdioUploadRecipeTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.view.CodeLocationView;
@@ -15,7 +16,9 @@ import com.blackducksoftware.integration.hub.service.CodeLocationService;
 import com.blackducksoftware.integration.hub.service.HubService;
 import com.blackducksoftware.integration.hub.service.ProjectService;
 import com.blackducksoftware.integration.hub.service.model.ProjectVersionWrapper;
+import com.blackducksoftware.integration.test.annotation.IntegrationTest;
 
+@Category(IntegrationTest.class)
 public class BdioUploadRecipeTest extends BasicRecipe {
     private final String codeLocationName = "hub_common_27_0_0_SNAPSHOT_upload_recipe";
     private final String uniqueProjectName = "hub-common_with_project_in_bdio";

--- a/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/CheckPolicyForProjectVersionRecipeTest.groovy
+++ b/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/CheckPolicyForProjectVersionRecipeTest.groovy
@@ -4,6 +4,7 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 import com.blackducksoftware.integration.hub.api.enumeration.PolicyRuleConditionOperatorType
 import com.blackducksoftware.integration.hub.api.generated.component.PolicyRuleExpressionSetView
@@ -21,7 +22,9 @@ import com.blackducksoftware.integration.hub.service.PolicyRuleService
 import com.blackducksoftware.integration.hub.service.ProjectService
 import com.blackducksoftware.integration.hub.service.model.PolicyRuleExpressionSetBuilder
 import com.blackducksoftware.integration.hub.service.model.ProjectVersionWrapper
+import com.blackducksoftware.integration.test.annotation.IntegrationTest
 
+@Category(IntegrationTest.class)
 class CheckPolicyForProjectVersionRecipeTest extends BasicRecipe {
     ProjectVersionWrapper projectVersionWrapper
     PolicyRuleView policyRuleView

--- a/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/ComponentManagementRecipeTest.java
+++ b/src/test/groovy/com/blackducksoftware/integration/hub/api/recipe/ComponentManagementRecipeTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.blackducksoftware.integration.hub.api.generated.component.ProjectRequest;
 import com.blackducksoftware.integration.hub.api.generated.view.VersionBomComponentView;
@@ -14,7 +15,9 @@ import com.blackducksoftware.integration.hub.bdio.model.Forge;
 import com.blackducksoftware.integration.hub.bdio.model.externalid.ExternalId;
 import com.blackducksoftware.integration.hub.service.ProjectService;
 import com.blackducksoftware.integration.hub.service.model.ProjectVersionWrapper;
+import com.blackducksoftware.integration.test.annotation.IntegrationTest;
 
+@Category(IntegrationTest.class)
 public class ComponentManagementRecipeTest extends BasicRecipe {
     private ProjectVersionWrapper projectVersionWrapper;
 


### PR DESCRIPTION
The NotificationView had a content member and the sub-classes also have
a content field that causes a problem for gson.  Create a new class
ReducedNotificationView that does not contain a content member in order
for gson to deserialize into the correct types.