### PR TITLE
Fix optional use in NotificationContentDetial

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 plugins { id 'groovy' }
 
-version = '32.0.2-SNAPSHOT'
+version = '32.1.0-SNAPSHOT'
 
 apply plugin: 'com.blackducksoftware.integration.library'
 

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/NotificationResults.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/NotificationResults.java
@@ -44,6 +44,7 @@ public class NotificationResults {
         this.hubBucket = hubBucket;
     }
 
+    // TODO We should rename this to something like getCommonNotificationStates (but this would be a breaking change...)
     public Collection<CommonNotificationState> getNotificationContentItems() {
         if (notificationViewResults == null) {
             return Collections.emptyList();

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/LicenseLimitNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/LicenseLimitNotificationContent.java
@@ -68,7 +68,7 @@ public class LicenseLimitNotificationContent extends NotificationContent {
     }
 
     @Override
-    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+    public List<ProjectVersionDescription> getAffectedProjectVersionDescriptions() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/LicenseLimitNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/LicenseLimitNotificationContent.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.enumeration.LicenseLimitType;
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public class LicenseLimitNotificationContent extends NotificationContent {
     public LicenseLimitType licenseViolationType;
@@ -64,6 +65,11 @@ public class LicenseLimitNotificationContent extends NotificationContent {
     @Override
     public String getNotificationGroup() {
         return NotificationContentDetail.CONTENT_KEY_GROUP_LICENSE;
+    }
+
+    @Override
+    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+        return Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContent.java
@@ -26,6 +26,7 @@ package com.blackducksoftware.integration.hub.notification.content;
 import java.util.List;
 
 import com.blackducksoftware.integration.hub.api.core.HubComponent;
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public abstract class NotificationContent extends HubComponent {
     public abstract boolean providesPolicyDetails();
@@ -39,5 +40,7 @@ public abstract class NotificationContent extends HubComponent {
     public abstract List<NotificationContentDetail> getNotificationContentDetails();
 
     public abstract String getNotificationGroup();
+
+    public abstract List<ProjectVersionDescription> getProjectVersionDescriptions();
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContent.java
@@ -41,6 +41,6 @@ public abstract class NotificationContent extends HubComponent {
 
     public abstract String getNotificationGroup();
 
-    public abstract List<ProjectVersionDescription> getProjectVersionDescriptions();
+    public abstract List<ProjectVersionDescription> getAffectedProjectVersionDescriptions();
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContentDetail.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/NotificationContentDetail.java
@@ -65,50 +65,39 @@ public class NotificationContentDetail extends Stringable {
     public final static String CONTENT_KEY_SEPARATOR = "|";
 
     public static NotificationContentDetail createPolicyDetailWithComponentOnly(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
-            final String componentName, final String componentUri,
-            final String policyName, final String policyUri) {
+            final String componentName, final String componentUri, final String policyName, final String policyUri) {
         return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), component(componentUri), Optional.empty(), Optional.empty(),
-                Optional.of(policyName),
-                policy(policyUri), Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
-    public static NotificationContentDetail createPolicyDetailWithComponentVersion(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
-            final String componentName, final String componentVersionName,
-            final String componentVersionUri, final String policyName, final String policyUri) {
-        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), Optional.empty(), Optional.of(componentVersionName),
-                componentVersion(componentVersionUri),
                 Optional.of(policyName), policy(policyUri), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public static NotificationContentDetail createPolicyDetailWithComponentAndIssue(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
-            final String componentName, final String componentUri,
-            final String policyName, final String policyUri, final String componentIssueUri) {
-        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), component(componentUri), Optional.empty(), Optional.empty(),
-                Optional.of(policyName),
-                policy(policyUri), Optional.empty(), componentIssue(componentIssueUri), Optional.empty());
+    public static NotificationContentDetail createPolicyDetailWithComponentVersion(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
+            final String componentName, final String componentVersionName, final String componentVersionUri, final String policyName, final String policyUri) {
+        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), Optional.empty(), Optional.of(componentVersionName),
+                componentVersion(componentVersionUri), Optional.of(policyName), policy(policyUri), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    public static NotificationContentDetail createPolicyDetailWithComponentVersionAndIssue(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
-            final String componentName,
-            final String componentVersionName,
-            final String componentVersionUri, final String policyName, final String policyUri, final String componentIssueUri) {
-        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), Optional.empty(), Optional.of(componentVersionName),
-                componentVersion(componentVersionUri),
+    public static NotificationContentDetail createPolicyDetailWithComponentAndIssue(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
+            final String componentName, final String componentUri, final String policyName, final String policyUri, final String componentIssueUri) {
+        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), component(componentUri), Optional.empty(), Optional.empty(),
                 Optional.of(policyName), policy(policyUri), Optional.empty(), componentIssue(componentIssueUri), Optional.empty());
     }
 
-    public static NotificationContentDetail createVulnerabilityDetail(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri, final String componentName,
-            final String componentVersionName,
-            final String componentVersionUri, final String componentVersionOriginName, final String componentIssueUri, final String componentVersionOriginId) {
+    public static NotificationContentDetail createPolicyDetailWithComponentVersionAndIssue(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri,
+            final String componentName, final String componentVersionName, final String componentVersionUri, final String policyName, final String policyUri, final String componentIssueUri) {
         return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), Optional.empty(), Optional.of(componentVersionName),
-                componentVersion(componentVersionUri),
-                Optional.empty(), Optional.empty(), Optional.of(componentVersionOriginName), componentIssue(componentIssueUri), Optional.of(componentVersionOriginId));
+                componentVersion(componentVersionUri), Optional.of(policyName), policy(policyUri), Optional.empty(), componentIssue(componentIssueUri), Optional.empty());
+    }
+
+    public static NotificationContentDetail createVulnerabilityDetail(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final String projectVersionUri, final String componentName,
+            final String componentVersionName, final String componentVersionUri, final String componentVersionOriginName, final String componentIssueUri, final String componentVersionOriginId) {
+        return new NotificationContentDetail(notificationContent, projectName, projectVersionName, projectVersion(projectVersionUri), Optional.of(componentName), Optional.empty(), Optional.ofNullable(componentVersionName),
+                componentVersion(componentVersionUri), Optional.empty(), Optional.empty(), Optional.ofNullable(componentVersionOriginName), componentIssue(componentIssueUri), Optional.ofNullable(componentVersionOriginId));
     }
 
     private NotificationContentDetail(final NotificationContent notificationContent, final String projectName, final String projectVersionName, final Optional<UriSingleResponse<ProjectVersionView>> projectVersion,
-            final Optional<String> componentName,
-            final Optional<UriSingleResponse<ComponentView>> component, final Optional<String> componentVersionName, final Optional<UriSingleResponse<ComponentVersionView>> componentVersion, final Optional<String> policyName,
-            final Optional<UriSingleResponse<PolicyRuleViewV2>> policy, final Optional<String> componentVersionOriginName, final Optional<UriSingleResponse<IssueView>> componentIssue, final Optional<String> componentVersionOriginId) {
+            final Optional<String> componentName, final Optional<UriSingleResponse<ComponentView>> component, final Optional<String> componentVersionName, final Optional<UriSingleResponse<ComponentVersionView>> componentVersion,
+            final Optional<String> policyName, final Optional<UriSingleResponse<PolicyRuleViewV2>> policy, final Optional<String> componentVersionOriginName, final Optional<UriSingleResponse<IssueView>> componentIssue,
+            final Optional<String> componentVersionOriginId) {
         this.notificationContent = notificationContent;
         this.projectName = projectName;
         this.projectVersionName = projectVersionName;

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/PolicyOverrideNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/PolicyOverrideNotificationContent.java
@@ -24,7 +24,10 @@
 package com.blackducksoftware.integration.hub.notification.content;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public class PolicyOverrideNotificationContent extends NotificationContent {
     public String projectName;
@@ -83,6 +86,12 @@ public class PolicyOverrideNotificationContent extends NotificationContent {
     @Override
     public String getNotificationGroup() {
         return NotificationContentDetail.CONTENT_KEY_GROUP_POLICY;
+    }
+
+    @Override
+    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+        final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
+        return Arrays.asList(projectVersionDescription);
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/PolicyOverrideNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/PolicyOverrideNotificationContent.java
@@ -89,7 +89,7 @@ public class PolicyOverrideNotificationContent extends NotificationContent {
     }
 
     @Override
-    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+    public List<ProjectVersionDescription> getAffectedProjectVersionDescriptions() {
         final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
         return Arrays.asList(projectVersionDescription);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationClearedNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationClearedNotificationContent.java
@@ -85,7 +85,7 @@ public class RuleViolationClearedNotificationContent extends NotificationContent
     }
 
     @Override
-    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+    public List<ProjectVersionDescription> getAffectedProjectVersionDescriptions() {
         final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
         return Arrays.asList(projectVersionDescription);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationClearedNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationClearedNotificationContent.java
@@ -24,9 +24,12 @@
 package com.blackducksoftware.integration.hub.notification.content;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public class RuleViolationClearedNotificationContent extends NotificationContent {
     public String projectName;
@@ -79,6 +82,12 @@ public class RuleViolationClearedNotificationContent extends NotificationContent
     @Override
     public String getNotificationGroup() {
         return NotificationContentDetail.CONTENT_KEY_GROUP_POLICY;
+    }
+
+    @Override
+    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+        final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
+        return Arrays.asList(projectVersionDescription);
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationNotificationContent.java
@@ -24,9 +24,12 @@
 package com.blackducksoftware.integration.hub.notification.content;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public class RuleViolationNotificationContent extends NotificationContent {
     public String projectName;
@@ -79,6 +82,12 @@ public class RuleViolationNotificationContent extends NotificationContent {
     @Override
     public String getNotificationGroup() {
         return NotificationContentDetail.CONTENT_KEY_GROUP_POLICY;
+    }
+
+    @Override
+    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+        final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
+        return Arrays.asList(projectVersionDescription);
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/RuleViolationNotificationContent.java
@@ -85,7 +85,7 @@ public class RuleViolationNotificationContent extends NotificationContent {
     }
 
     @Override
-    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+    public List<ProjectVersionDescription> getAffectedProjectVersionDescriptions() {
         final ProjectVersionDescription projectVersionDescription = new ProjectVersionDescription(projectName, projectVersionName, projectVersion);
         return Arrays.asList(projectVersionDescription);
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/VulnerabilityNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/VulnerabilityNotificationContent.java
@@ -25,8 +25,10 @@ package com.blackducksoftware.integration.hub.notification.content;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.blackducksoftware.integration.hub.api.component.AffectedProjectVersion;
+import com.blackducksoftware.integration.hub.service.model.ProjectVersionDescription;
 
 public class VulnerabilityNotificationContent extends NotificationContent {
     public int newVulnerabilityCount;
@@ -75,6 +77,17 @@ public class VulnerabilityNotificationContent extends NotificationContent {
     @Override
     public String getNotificationGroup() {
         return NotificationContentDetail.CONTENT_KEY_GROUP_VULNERABILITY;
+    }
+
+    @Override
+    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+        final List<ProjectVersionDescription> projectVersionDescriptions = affectedProjectVersions
+                .stream()
+                .map(affectedProjectVersion -> {
+                    return new ProjectVersionDescription(affectedProjectVersion.projectName, affectedProjectVersion.projectVersionName, affectedProjectVersion.projectVersion);
+                })
+                .collect(Collectors.toList());
+        return projectVersionDescriptions;
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/notification/content/VulnerabilityNotificationContent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/notification/content/VulnerabilityNotificationContent.java
@@ -80,7 +80,7 @@ public class VulnerabilityNotificationContent extends NotificationContent {
     }
 
     @Override
-    public List<ProjectVersionDescription> getProjectVersionDescriptions() {
+    public List<ProjectVersionDescription> getAffectedProjectVersionDescriptions() {
         final List<ProjectVersionDescription> projectVersionDescriptions = affectedProjectVersions
                 .stream()
                 .map(affectedProjectVersion -> {

--- a/src/main/java/com/blackducksoftware/integration/hub/service/model/ProjectVersionDescription.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/model/ProjectVersionDescription.java
@@ -1,0 +1,26 @@
+package com.blackducksoftware.integration.hub.service.model;
+
+public class ProjectVersionDescription {
+    private final String projectName;
+    private final String projectVersionName;
+    private final String projectVersionUri;
+
+    public ProjectVersionDescription(final String projectName, final String projectVersionName, final String projectVersionUri) {
+        this.projectName = projectName;
+        this.projectVersionName = projectVersionName;
+        this.projectVersionUri = projectVersionUri;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public String getProjectVersionName() {
+        return projectVersionName;
+    }
+
+    public String getProjectVersionUri() {
+        return projectVersionUri;
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/hub/service/model/ProjectVersionDescription.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/model/ProjectVersionDescription.java
@@ -1,3 +1,26 @@
+/**
+ * hub-common
+ *
+ * Copyright (C) 2018 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.blackducksoftware.integration.hub.service.model;
 
 public class ProjectVersionDescription {


### PR DESCRIPTION
Things that not only can be null, but very often are null, should definitely be wrapped with Optional.ofNullable() instead of Optional.of(). Here are several that I could find. It appears that the others are correct.