### PR TITLE
Handling the deletion of the log directory

### DIFF
--- a/src/main/java/com/blackducksoftware/integration/hub/cli/parallel/ScanPathCallable.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/cli/parallel/ScanPathCallable.java
@@ -82,22 +82,20 @@ public class ScanPathCallable implements Callable<ScanTargetOutput> {
         logger.info(String.format("Starting the signature scan of %s", simpleScanUtility.getSignatureScanConfig().getScanTarget()));
         ScanSummaryView scanSummaryView = null;
         File dryRunFile = null;
-        File standardOutputFile = null;
-        File cliLogDirectory = null;
+        File logDirectory = null;
         final String scanTarget = simpleScanUtility.getSignatureScanConfig().getScanTarget();
         try {
             simpleScanUtility.setupAndExecuteScan(cliLocation);
 
             scanSummaryView = getScanSummaryFromFile(simpleScanUtility.getScanSummaryFile());
             dryRunFile = simpleScanUtility.getDryRunFile();
-            standardOutputFile = simpleScanUtility.getStandardOutputFile();
-            cliLogDirectory = simpleScanUtility.getCLILogDirectory();
+            logDirectory = simpleScanUtility.getLogDirectory();
         } catch (IllegalArgumentException | IntegrationException e) {
             final String errorMessage = String.format("There was a problem scanning target '%s' : %s", scanTarget, e.getMessage());
-            scanTargetOutput = ScanTargetOutput.FAILURE(scanTarget, cliLogDirectory, standardOutputFile, dryRunFile, scanSummaryView, errorMessage, e);
+            scanTargetOutput = ScanTargetOutput.FAILURE(scanTarget, logDirectory, dryRunFile, scanSummaryView, errorMessage, e);
             return scanTargetOutput;
         }
-        scanTargetOutput = ScanTargetOutput.SUCCESS(scanTarget, cliLogDirectory, standardOutputFile, dryRunFile, scanSummaryView);
+        scanTargetOutput = ScanTargetOutput.SUCCESS(scanTarget, logDirectory, dryRunFile, scanSummaryView);
 
         logger.info(String.format("Completed the signature scan of %s", simpleScanUtility.getSignatureScanConfig().getScanTarget()));
         return scanTargetOutput;

--- a/src/main/java/com/blackducksoftware/integration/hub/cli/summary/ScanTargetOutput.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/cli/summary/ScanTargetOutput.java
@@ -29,38 +29,35 @@ import com.blackducksoftware.integration.hub.api.view.ScanSummaryView;
 import com.blackducksoftware.integration.hub.summary.Result;
 
 public class ScanTargetOutput {
-    private final File cliLogDirectory;
+    private final File dryRunFile;
     private final String errorMessage;
     private final Exception exception;
+    private final File logDirectory;
     private final Result result;
-    private final File dryRunFile;
     private final ScanSummaryView scanSummaryView;
     private final String scanTarget;
-    private final File standardOutputFile;
 
-    private ScanTargetOutput(final File cliLogDirectory, final String errorMessage, final Exception exception, final Result result, final File dryRunFile, final ScanSummaryView scanSummaryView, final String scanTarget,
-            final File standardOutputFile) {
-        this.cliLogDirectory = cliLogDirectory;
+    private ScanTargetOutput(final String errorMessage, final Exception exception, final File logDirectory, final Result result, final File dryRunFile, final ScanSummaryView scanSummaryView, final String scanTarget) {
         this.errorMessage = errorMessage;
         this.exception = exception;
+        this.logDirectory = logDirectory;
         this.result = result;
         this.dryRunFile = dryRunFile;
         this.scanSummaryView = scanSummaryView;
         this.scanTarget = scanTarget;
-        this.standardOutputFile = standardOutputFile;
     }
 
-    public static ScanTargetOutput SUCCESS(final String scanTarget, final File cliLogDirectory, final File standardOutputFile, final File dryRunFile, final ScanSummaryView scanSummaryView) {
-        return new ScanTargetOutput(cliLogDirectory, null, null, Result.SUCCESS, dryRunFile, scanSummaryView, scanTarget, standardOutputFile);
+    public static ScanTargetOutput SUCCESS(final String scanTarget, final File logDirectory, final File dryRunFile, final ScanSummaryView scanSummaryView) {
+        return new ScanTargetOutput(null, null, logDirectory, Result.SUCCESS, dryRunFile, scanSummaryView, scanTarget);
     }
 
-    public static ScanTargetOutput FAILURE(final String scanTarget, final File cliLogDirectory, final File standardOutputFile, final File dryRunFile, final ScanSummaryView scanSummaryView, final String errorMessage,
+    public static ScanTargetOutput FAILURE(final String scanTarget, final File logDirectory, final File dryRunFile, final ScanSummaryView scanSummaryView, final String errorMessage,
             final Exception exception) {
-        return new ScanTargetOutput(cliLogDirectory, errorMessage, exception, Result.FAILURE, dryRunFile, scanSummaryView, scanTarget, standardOutputFile);
+        return new ScanTargetOutput(errorMessage, exception, logDirectory, Result.FAILURE, dryRunFile, scanSummaryView, scanTarget);
     }
 
-    public File getCliLogDirectory() {
-        return cliLogDirectory;
+    public File getLogDirectory() {
+        return logDirectory;
     }
 
     public String getErrorMessage() {
@@ -87,7 +84,4 @@ public class ScanTargetOutput {
         return scanTarget;
     }
 
-    public File getStandardOutputFile() {
-        return standardOutputFile;
-    }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
@@ -83,7 +83,7 @@ public class SignatureScannerService extends DataService {
                 logDirectories.add(scanTargetOutput.getLogDirectory());
             }
         }
-        cleanLogs(hubScanConfig.isCleanupLogsOnSuccess(), logDirectories, );
+        cleanLogs(hubScanConfig.isCleanupLogsOnSuccess(), logDirectories);
         mapCodeLocations(hubScanConfig.getCommonScanConfig().isDryRun(), scanSummaryViews);
         logger.info("Completed the post scan steps");
         return new ScanServiceOutput(projectVersionWrapper, scanTargetOutputs);

--- a/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
@@ -24,9 +24,12 @@
 package com.blackducksoftware.integration.hub.service;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+
+import org.apache.commons.io.FileUtils;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
 import com.blackducksoftware.integration.hub.api.generated.component.ProjectRequest;
@@ -73,16 +76,14 @@ public class SignatureScannerService extends DataService {
 
         logger.info("Starting the post scan steps");
         final List<ScanSummaryView> scanSummaryViews = new ArrayList<>();
-        final List<File> standardOutputFiles = new ArrayList<>();
-        final List<File> cliLogDirectories = new ArrayList<>();
+        final List<File> logDirectories = new ArrayList<>();
         for (final ScanTargetOutput scanTargetOutput : scanTargetOutputs) {
             if (scanTargetOutput.getResult() == Result.SUCCESS) {
                 scanSummaryViews.add(scanTargetOutput.getScanSummaryView());
-                standardOutputFiles.add(scanTargetOutput.getStandardOutputFile());
-                cliLogDirectories.add(scanTargetOutput.getCliLogDirectory());
+                logDirectories.add(scanTargetOutput.getLogDirectory());
             }
         }
-        postScan(hubScanConfig.isCleanupLogsOnSuccess(), standardOutputFiles, cliLogDirectories, hubScanConfig.getCommonScanConfig().isDryRun(), scanSummaryViews);
+        postScan(hubScanConfig.isCleanupLogsOnSuccess(), logDirectories, hubScanConfig.getCommonScanConfig().isDryRun(), scanSummaryViews);
         logger.info("Completed the post scan steps");
         return new ScanServiceOutput(projectVersionWrapper, scanTargetOutputs);
     }
@@ -117,23 +118,17 @@ public class SignatureScannerService extends DataService {
         hubScanConfig.print(logger);
     }
 
-    private void postScan(final boolean cleanupLogDirectories, final List<File> standardOutputFiles, final List<File> cliLogDirectories, final boolean dryRun, final List<ScanSummaryView> scanSummaryViews)
+    private void postScan(final boolean cleanupLogDirectories, final List<File> logDirectories, final boolean dryRun, final List<ScanSummaryView> scanSummaryViews)
             throws IntegrationException {
         if (cleanupLogDirectories) {
-            if (!standardOutputFiles.isEmpty()) {
-                for (final File standardOutputFile : standardOutputFiles) {
-                    if (null != standardOutputFile && standardOutputFile.exists()) {
-                        standardOutputFile.delete();
-                    }
-                }
-            }
-            if (!cliLogDirectories.isEmpty()) {
-                for (final File cliLogDirectory : cliLogDirectories) {
-                    if (null != cliLogDirectory && cliLogDirectory.isDirectory()) {
-                        for (final File log : cliLogDirectory.listFiles()) {
-                            log.delete();
+            if (null != logDirectories && !logDirectories.isEmpty()) {
+                for (final File logDirectory : logDirectories) {
+                    if (null != logDirectory && logDirectory.isDirectory()) {
+                        try {
+                            FileUtils.deleteDirectory(logDirectory);
+                        } catch (IOException e) {
+                            logger.error(String.format("Could not delete the directory '%s' because: %s", logDirectory.getAbsolutePath(), e.getMessage()), e);
                         }
-                        cliLogDirectory.delete();
                     }
                 }
             }
@@ -149,4 +144,5 @@ public class SignatureScannerService extends DataService {
             }
         }
     }
+
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/service/SignatureScannerService.java
@@ -83,7 +83,8 @@ public class SignatureScannerService extends DataService {
                 logDirectories.add(scanTargetOutput.getLogDirectory());
             }
         }
-        postScan(hubScanConfig.isCleanupLogsOnSuccess(), logDirectories, hubScanConfig.getCommonScanConfig().isDryRun(), scanSummaryViews);
+        cleanLogs(hubScanConfig.isCleanupLogsOnSuccess(), logDirectories, );
+        mapCodeLocations(hubScanConfig.getCommonScanConfig().isDryRun(), scanSummaryViews);
         logger.info("Completed the post scan steps");
         return new ScanServiceOutput(projectVersionWrapper, scanTargetOutputs);
     }
@@ -118,8 +119,7 @@ public class SignatureScannerService extends DataService {
         hubScanConfig.print(logger);
     }
 
-    private void postScan(final boolean cleanupLogDirectories, final List<File> logDirectories, final boolean dryRun, final List<ScanSummaryView> scanSummaryViews)
-            throws IntegrationException {
+    private void cleanLogs(final boolean cleanupLogDirectories, final List<File> logDirectories) {
         if (cleanupLogDirectories) {
             if (null != logDirectories && !logDirectories.isEmpty()) {
                 for (final File logDirectory : logDirectories) {
@@ -133,6 +133,9 @@ public class SignatureScannerService extends DataService {
                 }
             }
         }
+    }
+
+    private void mapCodeLocations(final boolean dryRun, final List<ScanSummaryView> scanSummaryViews) throws IntegrationException {
         logger.trace(String.format("Scan is dry run %s", dryRun));
         if (!dryRun) {
             for (final ScanSummaryView scanSummaryView : scanSummaryViews) {


### PR DESCRIPTION
We used to clean some of the files on success, this is to delete all of the files in the log directory and the directory itself when the scan is successful and is configured for cleanup