### PR TITLE
Consider BDS_JAVA_HOME for Signature Scanner Execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,4 +21,7 @@ dependencies {
 
     testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
     testCompile 'org.mockito:mockito-core:2.18.3'
+    testCompile 'org.powermock:powermock-core:2.0.0-beta.5'
+    testCompile 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
+    testCompile 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
 }

--- a/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
@@ -40,6 +40,8 @@ import com.synopsys.integration.util.OperatingSystemType;
 public class ScanPathsUtility {
     public static final String STANDARD_OUT_FILENAME = "CLI_Output.txt";
 
+    public static final String BDS_JAVA_HOME = "BDS_JAVA_HOME";
+
     private static final String JAVA_PATH_FORMAT = "bin" + File.separator + "%s";
     private static final String WINDOWS_JAVA_PATH = String.format(JAVA_PATH_FORMAT, "java.exe");
     private static final String OTHER_JAVA_PATH = String.format(JAVA_PATH_FORMAT, "java");
@@ -83,10 +85,16 @@ public class ScanPathsUtility {
             logger.debug(String.format("The directory structure was likely created manually - be sure the jre folder exists in: %s", installDirectory.getAbsolutePath()));
         }
 
-        final File jreContentsDirectory = findFirstFilteredFile(installDirectory, JRE_DIRECTORY_FILTER, "Could not find the 'jre' directory in %s.");
+        final String pathToJavaExecutable;
+        if(System.getenv(BDS_JAVA_HOME)!=null) {
+            pathToJavaExecutable = System.getenv(BDS_JAVA_HOME);
+        } else {
+            final File jreContentsDirectory = findFirstFilteredFile(installDirectory, JRE_DIRECTORY_FILTER, "Could not find the 'jre' directory in %s.");
+            pathToJavaExecutable = findPathToJavaExe(jreContentsDirectory);
+        }
+
         final File libDirectory = findFirstFilteredFile(installDirectory, LIB_DIRECTORY_FILTER, "Could not find the 'lib' directory in %s.");
 
-        final String pathToJavaExecutable = findPathToJavaExe(jreContentsDirectory);
         final String pathToOneJar = findPathToStandaloneJar(libDirectory);
         final String pathToScanExecutable = findPathToScanCliJar(libDirectory);
 


### PR DESCRIPTION
Executing Signature Scanner from Blackduck Hub currently fails on
Alpine Linux environments as the Oracle JRE packaged with Signature
Scanner requires glibc, which is not present on Alpine Linux. They use
musl libc instead.

Executing Signature Scanner with the systems default OpenJDK JRE is not
possible as hub-common uses the Oracle JDK packaged with Signature
Scanner.

Starting Signature Scanner from command line works, as it considers the
environment variable BDS_JAVA_HOME and takes the JRE located there
instead of the Oracle JRE pacakged with Signature Scanner.

Unit tests are done with PowerMock instead of a wrapper class for
java.lang.System so the constructor of ScanPathsUtility stays the same
as it is used by hub-detect and as such changing it would cause
incompatibility. We had to use a beta version of PowerMock as others
are not yet compatible with Mockito2.

Fixes #224