### PR TITLE
Fix Java Executable Path for Signature Scanner

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
@@ -97,7 +97,7 @@ public class ScanPathsUtility {
         final String pathToJavaExecutable;
         final String bdsJavaHome = intEnvironmentVariables.getValue(BDS_JAVA_HOME);
         if (StringUtils.isNotBlank(bdsJavaHome)) {
-            pathToJavaExecutable = bdsJavaHome;
+            pathToJavaExecutable = findPathToJavaExe(new File(bdsJavaHome));
         } else {
             final File jreContentsDirectory = findFirstFilteredFile(installDirectory, JRE_DIRECTORY_FILTER, "Could not find the 'jre' directory in %s.");
             pathToJavaExecutable = findPathToJavaExe(jreContentsDirectory);

--- a/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
+++ b/src/main/java/com/synopsys/integration/blackduck/signaturescanner/command/ScanPathsUtility.java
@@ -75,7 +75,11 @@ public class ScanPathsUtility {
      * @throws HubIntegrationException
      */
     public ScanPaths determineSignatureScannerPaths(final File directory) throws HubIntegrationException {
-        if (directory == null || !directory.isDirectory()) {
+        if (directory == null) {
+            throw new IllegalArgumentException("null is not a valid directory");
+        }
+
+        if (!directory.isDirectory()) {
             throw new IllegalArgumentException(String.format("%s is not a valid directory", directory.getAbsolutePath()));
         }
 

--- a/src/test/groovy/com/synopsys/integration/blackduck/signaturescanner/ScanPathsTest.java
+++ b/src/test/groovy/com/synopsys/integration/blackduck/signaturescanner/ScanPathsTest.java
@@ -29,8 +29,6 @@ public class ScanPathsTest {
     // Example ...BlackDuckScanOutput\2018-09-16_15-38-37-050_1
     private static final String DATE_AND_THREAD_SPECIFIC_NAME = ".*\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}_\\S+";
 
-    private static final String VALUE_OF_BDS_JAVA_HOME = "valueOfBdsJavaHome";
-
     private IntEnvironmentVariables intEnvironmentVariables = new IntEnvironmentVariables();
 
     private final ScanPathsUtility macScanPathsUtility = new ScanPathsUtility(new TestLogger(), intEnvironmentVariables, OperatingSystemType.MAC);
@@ -38,6 +36,7 @@ public class ScanPathsTest {
     private final ScanPathsUtility linuxScanPathsUtility = new ScanPathsUtility(new TestLogger(), intEnvironmentVariables, OperatingSystemType.LINUX);
 
     private File tempDirectory;
+    private File bdsJavaHomeDirectory;
     private File macSetup;
     private File windowsSetup;
     private File linuxSetup;
@@ -50,11 +49,18 @@ public class ScanPathsTest {
         createMacSetup(tempDirectory);
         createWindowsSetup(tempDirectory);
         createLinuxSetup(tempDirectory);
+
+        final Path bdsJavaHomeDirectoryPath = Files.createTempDirectory("bds_java_home");
+        bdsJavaHomeDirectory = bdsJavaHomeDirectoryPath.toFile();
+
+        createWindowsJvm(bdsJavaHomeDirectory);
+        createOtherJvm(bdsJavaHomeDirectory);
     }
 
     @After
     public void deleteTempDirectory() {
         FileUtils.deleteQuietly(tempDirectory);
+        FileUtils.deleteQuietly(bdsJavaHomeDirectory);
         intEnvironmentVariables = new IntEnvironmentVariables();
     }
 
@@ -106,15 +112,15 @@ public class ScanPathsTest {
 
     @Test
     public void testJavaExecutablePathWithBdsJavaHome() throws Exception {
-        intEnvironmentVariables.put(BDS_JAVA_HOME, VALUE_OF_BDS_JAVA_HOME);
+        intEnvironmentVariables.put(BDS_JAVA_HOME, bdsJavaHomeDirectory.getAbsolutePath());
 
         final ScanPaths macScanPaths = macScanPathsUtility.determineSignatureScannerPaths(macSetup);
         final ScanPaths windowsScanPaths = windowsScanPathsUtility.determineSignatureScannerPaths(windowsSetup);
         final ScanPaths linuxScanPaths = linuxScanPathsUtility.determineSignatureScannerPaths(linuxSetup);
 
-        assertThat(macScanPaths.getPathToJavaExecutable(), is(VALUE_OF_BDS_JAVA_HOME));
-        assertThat(windowsScanPaths.getPathToJavaExecutable(), is(VALUE_OF_BDS_JAVA_HOME));
-        assertThat(linuxScanPaths.getPathToJavaExecutable(), is(VALUE_OF_BDS_JAVA_HOME));
+        assertThat(macScanPaths.getPathToJavaExecutable(), is(bdsJavaHomeDirectory + File.separator + "bin" + File.separator + "java"));
+        assertThat(windowsScanPaths.getPathToJavaExecutable(), is(bdsJavaHomeDirectory + File.separator + "bin" + File.separator + "java.exe"));
+        assertThat(linuxScanPaths.getPathToJavaExecutable(), is(bdsJavaHomeDirectory + File.separator + "bin" + File.separator + "java"));
     }
 
     private void assertScanPathsOk(final ScanPaths scanPaths, final boolean managedByLibrary) {
@@ -184,6 +190,22 @@ public class ScanPathsTest {
 
         final File implStandaloneJar = new File(cache, "scan.cli.impl-standalone.jar");
         implStandaloneJar.createNewFile();
+    }
+
+    private void createWindowsJvm(final File tempDirectory) throws IOException {
+        final File javaBin = new File(tempDirectory, "bin");
+        javaBin.mkdirs();
+
+        final File javaExe = new File(javaBin, "java.exe");
+        javaExe.createNewFile();
+    }
+
+    private void createOtherJvm(final File tempDirectory) throws IOException {
+        final File javaBin = new File(tempDirectory, "bin");
+        javaBin.mkdirs();
+
+        final File javaExe = new File(javaBin, "java");
+        javaExe.createNewFile();
     }
 
 }


### PR DESCRIPTION
When BDS_JAVA_HOME was set, its value was used as the java executable
path. By convention any JAVA_HOME variable usually points to the
installation directory of the JVM though, e.g.
/usr/lib/jvm/java-8-openjdk-amd64/jre. Hence, to determine the path to
the java executable correctly, we need to append /bin/java or
/bin/java.exe

Fixes #224