### PR TITLE
Fix: matched files not properly retrieved.

### DIFF
--- a/src/main/java/com/synopsys/integration/blackduck/service/ProjectService.java
+++ b/src/main/java/com/synopsys/integration/blackduck/service/ProjectService.java
@@ -288,7 +288,7 @@ public class ProjectService extends DataService {
     private List<MatchedFileView> getMatchedFiles(final VersionBomComponentView component) throws IntegrationException {
         List<MatchedFileView> matchedFiles = new ArrayList<>(0);
         final List<MatchedFileView> tempMatchedFiles = hubService.getAllResponses(component, VersionBomComponentView.MATCHED_FILES_LINK_RESPONSE);
-        if (tempMatchedFiles != null && tempMatchedFiles.isEmpty()) {
+        if (tempMatchedFiles != null && !tempMatchedFiles.isEmpty()) {
             matchedFiles = tempMatchedFiles;
         }
         return matchedFiles;


### PR DESCRIPTION
Problem:  Calls to `ProjectService::getComponentsWithMatchedFilesForProjectVersion` and `ProjectService::getMatchedFiles` will return `VersionBomComponentModel` objects having no `matchedFiles`.

In my debugging tests, in `getAllResponses` the call to `hubService.getAllResponses` correctly retrieves a list of `MatchedFileView`, but the function will return an empty list if `getAllResponses` returned a non-empty list, otherwise it will return… also an empty list.

I could not test the modified code because I cannot build the project (my local proxy prevents me for downloading the dependencies).