### PR TITLE
Add check for architecture with Alpine OS

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/signaturescanner/command/ToolsApiScannerInstaller.java
@@ -176,6 +176,10 @@ public class ToolsApiScannerInstaller extends ApiScannerInstaller {
     }
 
     private boolean isAlpineLinux() {
+        if (!osArchitecture.equals("aarch64") && !osArchitecture.equals("arm64")) {
+            return false;
+        }
+
         if(new File(ALPINE_OS_RELEASE_PATH).exists()) {
             return true;
         } else if(new File(OS_RELEASE_PATH).exists()) {


### PR DESCRIPTION
This PR will ensure we do not set the value as alpine_linux when architecture is not `arm64` since currently there is no scan-cli available for `x64` type alpine_linux to download.