### PR TITLE
Stop Retrying BDIO Uploads on HTTP 412 Precondition Failed Response

### DIFF
--- a/src/main/java/com/blackduck/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
+++ b/src/main/java/com/blackduck/integration/blackduck/bdio2/Bdio2RetryAwareStreamUploader.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class Bdio2RetryAwareStreamUploader {
-    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 409);
+    private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 409, 412);
     private static final Integer TOO_MANY_REQUESTS_CODE = 429;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final Bdio2StreamUploader bdio2StreamUploader;


### PR DESCRIPTION
**JIRA Ticket**

The detect ticket IDETECT-4786 depends on this fix.

**Description**

This change updates the `Bdio2RetryAwareStreamUploader` class to include **HTTP 412 (Precondition Failed)** in the `NON_RETRYABLE_EXIT_CODES` list.

Currently, detect **retries BDIO uploads for up to 5 minutes** when receiving a `412 Precondition Failed` response from the Black Duck server. This behavior is not desirable because:

- **HTTP 412 is a client-side error**, indicating that the request's preconditions (e.g., `If-Match`, `If-Unmodified-Since`) were not met.
- Retrying the same request **without modifying the preconditions** will always result in the same failure.
- According to [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/412), this status code is **non-retryable** unless the client changes the request logic.

**Context**

- In SCASS-enabled environments, detect attempts to initiate a scan package manager scan via a POST to `/api/intelligent-persistence-scans`, which returns a `412`.
- detect then retries this upload unnecessarily, leading to wasted time and misleading logs.

**Proposed Solution**

Added `412` to the `NON_RETRYABLE_EXIT_CODES` list:
```java
private static final List<Integer> NON_RETRYABLE_EXIT_CODES = Arrays.asList(401, 402, 403, 404, 409, 412);
```

**Impact**

- Fixes the issue where Detect unnecessarily retries BDIO uploads when SCASS is enabled and the server responds with a 412.
- Prevents wasted time and misleading logs by skipping retry attempts for 412 responses.
- Ensures Detect proceeds to the next step immediately, improving scan efficiency and clarity.