### PR TITLE
(breaking change): Remove API call to query for a user's most recent notification. Code locations by Detect will be created without querying notifications API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.ext.moduleName = 'com.blackduck.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '67.0.21-SNAPSHOT'
+version = '67.0.21-SNAPSHOT-shanty'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.ext.moduleName = 'com.blackduck.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '67.0.21-SNAPSHOT-shanty'
+version = '67.0.21'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.ext.moduleName = 'com.blackduck.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '67.0.21'
+version = '67.0.21-SNAPSHOT'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ project.ext.moduleName = 'com.blackduck.integration.blackduck-common'
 project.ext.javaUseAutoModuleName = 'true'
 project.ext.junitShowStandardStreams = 'true'
 
-version = '67.0.21-SNAPSHOT'
+version = '68.0.0-SNAPSHOT'
 
 description = 'A library for using various capabilities of Black Duck, notably the REST API and signature scanning.'
 

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/CodeLocationCreationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/CodeLocationCreationService.java
@@ -91,7 +91,7 @@ public class CodeLocationCreationService extends DataService {
 
         UrlSingleResponse<UserView> userResponse = apiDiscovery.metaSingleResponse(ApiDiscovery.CURRENT_USER_PATH);
         UserView currentUser = blackDuckApiClient.getResponse(userResponse);
-        Date startDate = notificationService.getLatestUserNotificationDate(currentUser);
+        Date startDate = new Date(System.currentTimeMillis());
         Date endDate = Date.from(threeDaysLater.atZone(ZoneOffset.UTC).toInstant());
 
         return new NotificationTaskRange(startTime, startDate, endDate);

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/CodeLocationCreationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/CodeLocationCreationService.java
@@ -47,6 +47,12 @@ public class CodeLocationCreationService extends DataService {
         return new CodeLocationCreationData<>(notificationTaskRange, output);
     }
 
+    public <T extends CodeLocationBatchOutput<?>> CodeLocationCreationData<T> createCodeLocationsWithoutNotificationTaskRange(CodeLocationCreationRequest<T> codeLocationCreationRequest) throws IntegrationException {
+        T output = codeLocationCreationRequest.executeRequest();
+
+        return new CodeLocationCreationData<>(null, output);
+    }
+
     public <T extends CodeLocationBatchOutput<?>> T createCodeLocationsAndWait(CodeLocationCreationRequest<T> codeLocationCreationRequest, long timeoutInSeconds) throws IntegrationException, InterruptedException {
         return createCodeLocationsAndWait(codeLocationCreationRequest, timeoutInSeconds, DEFAULT_WAIT_INTERVAL_IN_SECONDS);
     }

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadService.java
@@ -42,6 +42,11 @@ public class BinaryScanUploadService extends DataService {
         return uploadBinaryScan(uploadRequest);
     }
 
+    public CodeLocationCreationData<BinaryScanBatchOutput> uploadBinaryScanWithoutNotificationsQuery(BinaryScanBatch uploadBatch) throws IntegrationException {
+        BinaryScanCodeLocationCreationRequest uploadRequest = createUploadRequest(uploadBatch);
+        return codeLocationCreationService.createCodeLocationsWithoutNotificationTaskRange(uploadRequest);
+    }
+
     public CodeLocationCreationData<BinaryScanBatchOutput> uploadBinaryScan(BinaryScan binaryScan) throws IntegrationException {
         BinaryScanBatch uploadBatch = new BinaryScanBatch();
         uploadBatch.addBinaryScan(binaryScan);

--- a/src/main/java/com/blackduck/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/codelocation/intelligentpersistence/IntelligentPersistenceService.java
@@ -46,6 +46,11 @@ public class IntelligentPersistenceService extends DataService {
         return uploadBdio(uploadRequest);
     }
 
+    public CodeLocationCreationData<UploadBatchOutput> uploadBdioWithoutNotificationsQuery(UploadBatch uploadBatch, long timeoutInSeconds, long clientStartTime) throws IntegrationException {
+        IntelligentPersistenceCodeLocationCreationRequest uploadRequest = this.createUploadRequest(uploadBatch, timeoutInSeconds, clientStartTime);
+        return codeLocationCreationService.createCodeLocationsWithoutNotificationTaskRange(uploadRequest);
+    }
+
     public UploadBatchOutput uploadBdioAndWait(CodeLocationCreationRequest<UploadBatchOutput> uploadRequest, long timeoutInSeconds) throws IntegrationException, InterruptedException {
         return codeLocationCreationService.createCodeLocationsAndWait(uploadRequest, timeoutInSeconds);
     }

--- a/src/main/java/com/blackduck/integration/blackduck/service/dataservice/NotificationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/dataservice/NotificationService.java
@@ -85,6 +85,7 @@ public class NotificationService extends DataService {
      * @throws IntegrationException
      */
     public Date getLatestUserNotificationDate(UserView userView) throws IntegrationException {
+        logger.warn("Fetching latest notification date for user via a low‑performance API.");
         BlackDuckRequestBuilder blackDuckRequestBuilder = createLatestDateRequestBuilder();
         BlackDuckMultipleRequest<NotificationUserView> requestMultiple = blackDuckRequestBuilder.buildBlackDuckRequest(userNotificationsResponses.apply(userView));
         List<NotificationUserView> userNotifications = blackDuckApiClient.getSomeResponses(requestMultiple, 1);

--- a/src/main/java/com/blackduck/integration/blackduck/service/dataservice/NotificationService.java
+++ b/src/main/java/com/blackduck/integration/blackduck/service/dataservice/NotificationService.java
@@ -80,18 +80,6 @@ public class NotificationService extends DataService {
         return getFirstCreatedAtDate(notifications);
     }
 
-    /**
-     * @return The java.util.Date of the most recent notification in the user's stream. If there are no notifications, the current date will be returned. This can set an initial start time window for all future notifications.
-     * @throws IntegrationException
-     */
-    public Date getLatestUserNotificationDate(UserView userView) throws IntegrationException {
-        logger.warn("Fetching latest notification date for user via a low‑performance API.");
-        BlackDuckRequestBuilder blackDuckRequestBuilder = createLatestDateRequestBuilder();
-        BlackDuckMultipleRequest<NotificationUserView> requestMultiple = blackDuckRequestBuilder.buildBlackDuckRequest(userNotificationsResponses.apply(userView));
-        List<NotificationUserView> userNotifications = blackDuckApiClient.getSomeResponses(requestMultiple, 1);
-        return getFirstCreatedAtDate(userNotifications);
-    }
-
     private Date getFirstCreatedAtDate(List<? extends NotificationView> notifications) {
         if (notifications.size() == 1) {
             return notifications.get(0).getCreatedAt();

--- a/src/test/java/com/blackduck/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/codelocation/binaryscanner/BinaryScanUploadServiceTestIT.java
@@ -104,7 +104,7 @@ public class BinaryScanUploadServiceTestIT {
 
     private BinaryScanData createBinaryScanData(BlackDuckServices blackDuckServices, BinaryScan binaryScan) throws IntegrationException {
         UserView currentUser = blackDuckServices.userService.findCurrentUser();
-        Date userStartDate = blackDuckServices.notificationService.getLatestUserNotificationDate(currentUser);
+        Date userStartDate = new Date(System.currentTimeMillis());
         Date systemStartDate = blackDuckServices.notificationService.getLatestNotificationDate();
 
         return new BinaryScanData(currentUser, userStartDate, systemStartDate, binaryScan);

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/ComprehensiveCookbookTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/ComprehensiveCookbookTestIT.java
@@ -163,7 +163,7 @@ public class ComprehensiveCookbookTestIT {
         setupPolicyCheck(blackDuckServices, checkPolicyData);
 
         UserView currentUser = blackDuckServices.userService.findCurrentUser();
-        Date userStartDate = blackDuckServices.notificationService.getLatestUserNotificationDate(currentUser);
+        Date userStartDate = new Date(System.currentTimeMillis());
         Date systemStartDate = blackDuckServices.notificationService.getLatestNotificationDate();
 
         // import the bdio
@@ -197,7 +197,7 @@ public class ComprehensiveCookbookTestIT {
         setupPolicyCheck(blackDuckServices, checkPolicyData);
 
         UserView currentUser = blackDuckServices.userService.findCurrentUser();
-        Date userStartDate = blackDuckServices.notificationService.getLatestUserNotificationDate(currentUser);
+        Date userStartDate =  new Date(System.currentTimeMillis());
         Date systemStartDate = blackDuckServices.notificationService.getLatestNotificationDate();
 
         File scanFile = intHttpClientTestHelper.getFile("hub-artifactory-1.0.1-RC.zip");

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/CreateProjectWithBdioAndVerifyBOMTest.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/CreateProjectWithBdioAndVerifyBOMTest.java
@@ -113,7 +113,7 @@ public class CreateProjectWithBdioAndVerifyBOMTest {
     }
 
     private void uploadAndVerifyBdio(UploadBatch uploadBatch, Set<String> expectedCodeLocationNames) throws IntegrationException, InterruptedException {
-        Date startDate = blackDuckServices.notificationService.getLatestUserNotificationDate(currentUser);
+        Date startDate =  new Date(System.currentTimeMillis());
         System.out.println("start date: ");
         System.out.println(RestConstants.formatDate(startDate));
 

--- a/src/test/java/com/blackduck/integration/blackduck/comprehensive/NotificationsTestIT.java
+++ b/src/test/java/com/blackduck/integration/blackduck/comprehensive/NotificationsTestIT.java
@@ -50,7 +50,7 @@ public class NotificationsTestIT {
         ProjectSyncModel projectSyncModel = ProjectSyncModel.createWithDefaults(projectName, projectVersionName);
 
         UserView currentUser = userService.findCurrentUser();
-        Date startDate = notificationService.getLatestUserNotificationDate(currentUser);
+        Date startDate =  new Date(System.currentTimeMillis());
         Date endDate = Date.from(startDate.toInstant().plus(1, ChronoUnit.DAYS));
         List<String> notificationTypes = new ArrayList<>();
         notificationTypes.add(NotificationType.PROJECT.name());


### PR DESCRIPTION
See related Detect PR: https://github.com/blackducksoftware/detect/pull/1708 

Summary of changes: 
1. Alternative methods for creating code location without the use of notification service
2. Remove getLatestuserNotification() method and replace any uses with the current date instead.


This is considered a breaking change and will bump blackbuck-common version to 68.0.0