### PR TITLE
Update library dependencies for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ repositories {
 
 dependencies {
     api 'com.blackduck.integration:blackduck-common-api:2023.4.2.14'
-    api 'com.blackduck.integration:phone-home-client:7.0.2'
-    api 'com.blackduck.integration:integration-bdio:27.0.4'
+    api 'com.blackduck.integration:phone-home-client:7.0.3'
+    api 'com.blackduck.integration:integration-bdio:27.0.5'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'
 
     testImplementation 'com.google.guava:guava:31.1-jre'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.14'
+    api 'com.blackduck.integration:blackduck-common-api:2023.4.2.15'
     api 'com.blackduck.integration:phone-home-client:7.0.3'
     api 'com.blackduck.integration:integration-bdio:27.0.5'
     api 'com.blackducksoftware.bdio:bdio2:3.2.12'


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

 This pull request bumps the `blackduck-common-api` version to the latest release `2023.4.2.15`,  the `phone-home-client` version to the latest release `7.0.3`,  `integration-bdio` version to the latest release `27.0.5`.

The version upgrades bring the latest release of `integration-common:27.0.4` transitively. And, it updates  the direct dependency  `json-path` from `2.9.0` to `2.10.0` to resolve a transitive vulnerable dependency as part of the EU CRA compliance effort.
 
`json-path:2.9.0` pulls in `json-smart:2.5.0`, which carries **CVE-2024-57699 (BDSA-2025-0966)**. 
This update transitively brings in `json-smart:2.6.0`, which is free of this vulnerability, and thus the safe version flows to all downstream consumers automatically.