### PR TITLE
Update bdio library for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     api 'com.blackduck.integration:blackduck-common-api:2023.4.2.15'
     api 'com.blackduck.integration:phone-home-client:7.0.3'
     api 'com.blackduck.integration:integration-bdio:27.0.5'
-    api 'com.blackducksoftware.bdio:bdio2:3.2.12'
+    api 'com.blackducksoftware.bdio:bdio2:4.0.1'
 
     testImplementation 'com.google.guava:guava:31.1-jre'
 


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

This pull request bumps the `bdio2` library version to the latest release `4.0.1`.

The version upgrade transitively upgrades `jackson-core`, `jackson-databind`, `jackson-annotations` from `2.15.0` to `2.18.6` to resolve BDSA-2026-6606 exploitable vulnerability.
This also changes transitive dependency `guava` from `30.1.1-jre` to `32.0.1-jre` to resolve BDSA-2020-3736
(CVE-2020-8908) exploitable vulnerability.  

As part of the EU CRA compliance effort, these upgrades removes exploitable vulnerabilities in the `blackduck-common` library and thus the safe versions of these dependencies flow to all downstream consumers automatically.
